### PR TITLE
feat(lab): KaTeX formulas, clarity rewrites & visual/3D fixes across all 14 pieces

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@sparticuz/chromium": "^149.0.0",
         "@tailwindcss/vite": "^4.3.2",
         "astro": "^7.0.7",
+        "katex": "^0.18.1",
         "marked": "^17.0.6",
         "puppeteer-core": "^25.3.0",
         "tailwindcss": "^4.3.2",
@@ -15,6 +16,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.1",
+        "@types/katex": "^0.16.8",
         "@types/three": "^0.185.1",
       },
     },
@@ -354,6 +356,8 @@
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
+    "@types/katex": ["@types/katex@0.16.8", "", {}, "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg=="],
+
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
@@ -422,7 +426,7 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
-    "commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "common-ancestor-path": ["common-ancestor-path@2.0.0", "", {}, "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng=="],
 
@@ -541,6 +545,8 @@
     "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
+
+    "katex": ["katex@0.18.1", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Td8GCYSxDAoMhHOlKmCFMJ/hz5qlAAb71n66Dryw9nfCVfumLo7nhuotbvKom/XPADmrYC3O5QR71EPq4DarJQ=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -813,6 +819,8 @@
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@sparticuz/chromium": "^149.0.0",
     "@tailwindcss/vite": "^4.3.2",
     "astro": "^7.0.7",
+    "katex": "^0.18.1",
     "marked": "^17.0.6",
     "puppeteer-core": "^25.3.0",
     "tailwindcss": "^4.3.2",
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",
+    "@types/katex": "^0.16.8",
     "@types/three": "^0.185.1"
   }
 }

--- a/src/components/ChiralityPage.astro
+++ b/src/components/ChiralityPage.astro
@@ -1,5 +1,6 @@
 ---
 import { getLangFromUrl, getLocalizedPath } from '../i18n/utils';
+import Formula from './Formula.astro';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -9,7 +10,11 @@ const copy = {
     label: 'Lab 11 — Biochemistry',
     title: '光学異性体と、薬が効く理由',
     intro:
-      '4つの異なる基が結びついた炭素は、右手と左手のように「重ね合わせられない鏡像」を2つ持ちます — これが光学異性体（エナンチオマー）です。体内のタンパク質（受容体・酵素）はそれ自身が左右非対称なので、片方の異性体だけがポケットにぴったりはまり、薬として働きます。もう片方は同じ原子で出来ているのに、はまらない、あるいは別の作用をする。分子の「かたち」と「手性（きき手）」が効き目を決めているのです。',
+      '4つの異なる基が結びついた炭素は、右手と左手のように「重ね合わせられない鏡像」を2つ持ちます — これが光学異性体（エナンチオマー）です。体内のタンパク質（受容体・酵素）はそれ自身が左右非対称なので、片方の異性体だけがポケットにぴったりはまり、薬として働きます。もう片方は同じ原子で出来ているのに、はまらない、あるいは別の作用をする。分子の「かたち」と「手性（右手か左手か）」が効き目を決めているのです。',
+    formula: String.raw`\begin{aligned}\text{受容体} + R &\longrightarrow 3/3\ \text{接触} \longrightarrow \text{結合（活性）} \\ \text{受容体} + S &\longrightarrow {<}\,3\ \text{接触} \longrightarrow \text{不適合（不活性）}\end{aligned}`,
+    formulaLabel: '3点相互作用モデル',
+    receptorLabel: '受容体',
+    drugLabel: '薬',
     hint: 'R体は3点すべてが合ってはまる。S体（鏡像）に切り替えると色が合わず、はまらない',
     handLabel: '異性体',
     mirror: 'S（鏡像）',
@@ -24,6 +29,10 @@ const copy = {
     title: 'Chirality: Why a Drug Works',
     intro:
       'A carbon bonded to four different groups comes in two non-superimposable mirror images, like a left and a right hand — these are enantiomers (optical isomers). The proteins in your body (receptors, enzymes) are themselves handed, so typically only one enantiomer fits the pocket and acts as a drug. The mirror image is made of the exact same atoms, yet it may not fit at all, or do something entirely different. Shape and handedness decide the effect.',
+    formula: String.raw`\begin{aligned}\text{Receptor} + R &\longrightarrow 3/3\ \text{contacts} \longrightarrow \text{binds (active)} \\ \text{Receptor} + S &\longrightarrow {<}\,3\ \text{contacts} \longrightarrow \text{no fit (inactive)}\end{aligned}`,
+    formulaLabel: 'Three-point attachment model',
+    receptorLabel: 'Receptor',
+    drugLabel: 'Drug',
     hint: 'The R form matches all three points and docks. Switch to S (the mirror image) and the colors no longer line up',
     handLabel: 'Enantiomer',
     mirror: 'S (mirror)',
@@ -42,15 +51,16 @@ const t = copy[lang];
   <h1 class="page-title mt-2">{t.title}</h1>
   <p class="mt-5 text-[var(--ink-secondary)]">{t.intro}</p>
 
-  <p class="lab-formula" aria-label="Three-point attachment">
-    受容体 + <i>R</i> → 3/3 接触 → 結合（活性）
-    &ensp;;&ensp;
-    受容体 + <i>S</i> → &lt; 3 接触 → 不適合（不活性）
-  </p>
+  <Formula label={t.formulaLabel} tex={t.formula} />
 
   <div class="glass mt-8 overflow-hidden">
     <div class="lab-stage">
-      <canvas id="chirality-canvas" class="lab-canvas" aria-label={t.title}></canvas>
+      <canvas
+        id="chirality-canvas"
+        class="lab-canvas"
+        aria-label={t.title}
+        data-receptor={t.receptorLabel}
+        data-drug={t.drugLabel}></canvas>
       <p class="lab-hint">{t.hint}</p>
     </div>
 
@@ -81,13 +91,22 @@ const t = copy[lang];
     const inactiveText = verdictEl?.dataset.inactive ?? '';
     let lastBinds: boolean | null = null;
 
-    const scene = createChiralityScene(canvas, (_hand, binds) => {
-      if (verdictEl && binds !== lastBinds) {
-        verdictEl.textContent = binds ? activeText : inactiveText;
-        verdictEl.style.color = binds ? 'var(--accent)' : 'var(--ink)';
-        lastBinds = binds;
-      }
-    });
+    const labels = {
+      receptor: canvas.dataset.receptor ?? '',
+      drug: canvas.dataset.drug ?? '',
+    };
+
+    const scene = createChiralityScene(
+      canvas,
+      (_hand, binds) => {
+        if (verdictEl && binds !== lastBinds) {
+          verdictEl.textContent = binds ? activeText : inactiveText;
+          verdictEl.style.color = binds ? 'var(--accent)' : 'var(--ink)';
+          lastBinds = binds;
+        }
+      },
+      labels,
+    );
 
     const chips = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-hand]'));
     chips.forEach((chip) => {

--- a/src/components/EntropyPage.astro
+++ b/src/components/EntropyPage.astro
@@ -1,5 +1,6 @@
 ---
 import { getLangFromUrl, getLocalizedPath } from '../i18n/utils';
+import Formula from './Formula.astro';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -9,22 +10,22 @@ const copy = {
     label: 'Lab 03 — Statistical Mechanics',
     title: 'エントロピーと混合',
     intro:
-      '緑と金、2種類の理想気体 2,600 粒子が壁で仕切られた箱に入っています。数秒後、壁はひとりでに外れます。粒子はただ直進と反射を繰り返すだけ — それでも必ず混ざり、そして二度と元の左右分離には戻りません。逆向きの運動も物理法則としては完全に許されているのに、です。下のグラフは箱を 16×10 の格子に粗視化した混合エントロピー S。乱雑さへ向かう一方通行 — 第二法則は力ではなく、単なる「場合の数の数え上げ」の帰結です。',
-    hint: 'まもなく壁が外れる。ここから先は一方通行 — 何分眺めても元には戻らない',
+      '緑と金、2種類の理想気体 2,600 粒子が壁で仕切られた箱に入っています。数秒後、壁はひとりでに外れます。粒子はただ直進と反射を繰り返すだけ — それでも必ず混ざり、そして二度と元の左右分離には戻りません。逆向きの運動も物理法則としては完全に許されているのに、です。下のグラフは、箱を 16×10 のマス目に区切り、各マスで緑と金がどれだけ混ざったかを数え上げた混合エントロピー S。乱雑さへ向かう一方通行 — 第二法則は力ではなく、単なる「場合の数の数え上げ」の帰結です。',
+    hint: '壁はひとりでに外れる。ここから先は一方通行 — 何分眺めても元には戻らない',
     reset: 'もう一度最初から',
     entropy: '混合エントロピー',
-    note: 'S はゆらぎながら 1 に近づき、まれに少しだけ下がります — 小さな系ではエントロピーの減少も起こりうる（ゆらぎの定理）。ただし全粒子が左半分に戻る確率はおよそ 2⁻²⁶⁰⁰。宇宙の年齢を何回繰り返しても足りません。',
+    note: 'S はゆらぎながら 1 に近づき、まれに少しだけ下がります — 小さな系ではエントロピーの減少も起こりうる（ゆらぎの定理）。ただし緑がすべて左へ、金がすべて右へそろい直す確率はおよそ 2⁻²⁶⁰⁰。宇宙の年齢を何回繰り返しても足りません。',
   },
   en: {
     back: '← Lab',
     label: 'Lab 03 — Statistical Mechanics',
     title: 'Entropy & Mixing',
     intro:
-      'Two ideal gases — 2,600 particles of green and gold — sit in a box divided by a wall. After a few seconds the wall drops on its own. The particles do nothing but fly straight and bounce — yet they inevitably mix, and never return to the separated state, even though the reversed motion is perfectly allowed by the laws of physics. The chart tracks the mixing entropy S, coarse-grained on a 16×10 grid: a one-way street toward disorder. The second law is not a force; it is what counting configurations inevitably produces.',
-    hint: 'The wall is about to drop. From then on it is one-way — watch as long as you like, it never goes back',
+      'Two ideal gases — 2,600 particles of green and gold — sit in a box divided by a wall. After a few seconds the wall drops on its own. The particles do nothing but fly straight and bounce — yet they inevitably mix, and never return to the separated state, even though the reversed motion is perfectly allowed by the laws of physics. The chart tracks the mixing entropy S: divide the box into a 16×10 grid and score how evenly green and gold share each cell. A one-way street toward disorder — the second law is not a force; it is what counting configurations inevitably produces.',
+    hint: 'The wall drops on its own. From then on it is one-way — watch as long as you like, it never goes back',
     reset: 'Run it again',
     entropy: 'Mixing entropy',
-    note: 'S fluctuates on its way up and occasionally dips — in small systems entropy can briefly decrease (fluctuation theorem). But the chance of all particles returning to the left half is about 2⁻²⁶⁰⁰: not once in any number of ages of the universe.',
+    note: 'S fluctuates on its way up and occasionally dips — in small systems entropy can briefly decrease (fluctuation theorem). But the chance of every green particle finding the left half again and every gold the right is about 2⁻²⁶⁰⁰: not once in any number of ages of the universe.',
   },
 } as const;
 const t = copy[lang];
@@ -36,11 +37,10 @@ const t = copy[lang];
   <h1 class="page-title mt-2">{t.title}</h1>
   <p class="mt-5 text-[var(--ink-secondary)]">{t.intro}</p>
 
-  <p class="lab-formula" aria-label="Mixing entropy">
-    <i>S</i> = Σ<sub><i>c</i></sub> <i>w<sub>c</sub></i> · <i>H</i>(<i>f<sub>c</sub></i>)
-    &ensp;,&ensp;
-    <i>H</i>(<i>f</i>) = −[<i>f</i> ln <i>f</i> + (1−<i>f</i>) ln(1−<i>f</i>)] / ln 2
-  </p>
+  <Formula
+    label="Mixing entropy"
+    tex={String.raw`S = \sum_{c} w_c\, H(f_c), \qquad H(f) = -\dfrac{f \ln f + (1-f)\ln(1-f)}{\ln 2}`}
+  />
 
   <div class="glass mt-8 overflow-hidden">
     <div class="lab-stage">

--- a/src/components/FissionPage.astro
+++ b/src/components/FissionPage.astro
@@ -1,20 +1,24 @@
 ---
 import { getLangFromUrl, getLocalizedPath } from '../i18n/utils';
+import Formula from './Formula.astro';
 
 const lang = getLangFromUrl(Astro.url);
 
-// Mirrors the isotope constants in ../lib/lab/fission.ts (ISOTOPES). Kept as
-// plain literals here -- that module pulls in canvas/DOM code at import time
-// via ./viz, which is only safe inside the client <script>, not this
-// server-rendered frontmatter.
-const isotopeInfo = {
+// Isotope constant read-outs, as KaTeX so the ν̄ macron and unit spacing
+// render crisply. Mirrors the isotope constants in ../lib/lab/fission.ts
+// (ISOTOPES) — kept as plain literals here since that module pulls in
+// canvas/DOM code at import time via ./viz, only safe inside the client
+// <script>, not this server-rendered frontmatter. Both variants are
+// pre-rendered at build time and toggled by the isotope chips (the text is
+// KaTeX now, so JS can no longer just swap textContent).
+const isotopeTex = {
   ja: {
-    u235: 'ν̄ = 2.43 ・ E = 200 MeV/分裂 ・ 臨界質量 ≈ 52 kg',
-    pu239: 'ν̄ = 2.88 ・ E = 207 MeV/分裂 ・ 臨界質量 ≈ 10 kg',
+    u235: String.raw`\bar{\nu} = 2.43,\quad E = 200\ \mathrm{MeV}/\text{分裂},\quad \text{臨界質量} \approx 52\ \mathrm{kg}`,
+    pu239: String.raw`\bar{\nu} = 2.88,\quad E = 207\ \mathrm{MeV}/\text{分裂},\quad \text{臨界質量} \approx 10\ \mathrm{kg}`,
   },
   en: {
-    u235: 'ν̄ = 2.43, E = 200 MeV/fission, critical mass ≈ 52 kg',
-    pu239: 'ν̄ = 2.88, E = 207 MeV/fission, critical mass ≈ 10 kg',
+    u235: String.raw`\bar{\nu} = 2.43,\quad E = 200\ \mathrm{MeV/fission},\quad \text{critical mass} \approx 52\ \mathrm{kg}`,
+    pu239: String.raw`\bar{\nu} = 2.88,\quad E = 207\ \mathrm{MeV/fission},\quad \text{critical mass} \approx 10\ \mathrm{kg}`,
   },
 } as const;
 const K_MIN = 0.6;
@@ -27,7 +31,7 @@ const copy = {
     label: 'Lab 14 — Nuclear Physics',
     title: '核分裂の連鎖反応',
     intro:
-      '重い原子核(²³⁵U や ²³⁹Pu)に中性子が飛び込むと核分裂が起こります。核は2つの破片に割れ、中性子を数個放出しながら莫大なエネルギーを出します。例:²³⁵U + n → ¹⁴¹Ba + ⁹²Kr + 3n + 約200 MeV。放出された中性子が次の核を叩けばまた分裂が起こる、これが連鎖反応です。1回の分裂が平均何回の次の分裂を引き起こすかを表すのが実効増倍率 k。k<1 なら反応は減衰して止まり(未臨界)、k=1 なら中性子数は一定に保たれ(臨界、原子炉の状態)、k>1 なら指数関数的に増え続けます(超臨界、核爆発の領域)。中性子を発射し、k を動かしながら箱の中の連鎖反応を見てください。',
+      '重い原子核(²³⁵U や ²³⁹Pu)に中性子が飛び込むと核分裂が起こります。核は2つの破片に割れ、莫大なエネルギーとともに新しい中性子を平均2〜3個放出します。この平均が ν̄ です。例:²³⁵U + n → ¹⁴¹Ba + ⁹²Kr + 3n + 約200 MeV。放出された中性子が次の核を叩けばまた分裂が起こる、これが連鎖反応です。1回の分裂が平均して次の分裂を何回引き起こすか — それが実効増倍率 k。ν̄ に「中性子1個が次の分裂を起こす確率」を掛けたものです。k が1より小さければ反応はやがて減衰して止まります(未臨界)。ちょうど1なら中性子数は一定に保たれます(臨界。原子炉はこの状態で運転します)。1を超えると世代ごとに k 倍、指数関数的に増え続けます(超臨界、核爆発の領域)。中性子を発射し、k を動かしながら箱の中の連鎖反応を見てください。',
     hint: 'k を1より上げると、中性子が指数関数的に増えていく',
     isotopeLabel: '核種',
     kLabel: '実効増倍率 k',
@@ -40,15 +44,17 @@ const copy = {
     energy: '放出エネルギー',
     fissions: '分裂数',
     neutrons: '中性子数',
+    chartAria: '中性子数の推移',
+    chartCeiling: '上限',
     note:
-      '連鎖反応の運命は k だけで決まります。k<1(未臨界)では自然に減衰して止まり、k=1(臨界)では中性子数が一定に保たれます。原子炉の定常運転状態です。k>1(超臨界)では世代ごとに k 倍で指数関数的に増え続けます。臨界質量(裸の球体)はおよそ ²³⁵U で52 kg、²³⁹Pu で10 kg。中性子反射材で包めばもっと少なくて済みます。²³⁸U は分裂しにくい「親物質」で、中性子を吸収してもほとんどは分裂せず ²³⁹Pu へ変わるだけ。天然ウランの濃縮が必要な理由です。中性子の大部分は分裂と同時(即発)に出ますが、約0.65%は数秒から数十秒遅れて出ます(遅発中性子)。この遅れのおかげで原子炉は制御棒でゆっくり調整でき、暴走しにくくなっています。エネルギーの正体は質量欠損。核の質量が分裂前後で約0.1%軽くなり、その差が E=mc² として放出されます。1回の分裂で約200 MeV(約3.2×10⁻¹¹ J)、²³⁵U 1 g がすべて分裂すると約8×10¹⁰ J。石炭2.5トン分の熱量、TNT換算で約17トン分に相当します。広島に落とされたのはウラン砲身型、長崎はプルトニウム爆縮型。同じ物理が、制御されれば世界の原子力発電を支えています。',
+      '臨界質量は反射材なしの球形でおよそ ²³⁵U が52 kg、²³⁹Pu が10 kg。中性子を跳ね返す反射材で包めばもっと少なくて済みます。²³⁸U は分裂しにくい「親物質」で、中性子を吸収してもほとんどは分裂せず ²³⁹Pu へ変わるだけ。天然ウランに濃縮が必要な理由です。中性子の大部分は分裂と同時に出ます(即発)が、約0.65%は数秒から数十秒遅れて出ます(遅発中性子)。この遅れのおかげで原子炉は制御棒でゆっくり調整でき、暴走しにくくなっています。エネルギーの正体は質量欠損。分裂の前後で核の質量が約0.1%軽くなり、その差が E=mc² として放出されます。1回の分裂で約200 MeV(約3.2×10⁻¹¹ J)、²³⁵U 1 g がすべて分裂すると約8×10¹⁰ J。石炭2.5トン分の熱量、TNT換算で約17トンに相当します。広島に落とされたのはウラン砲身型、長崎はプルトニウム爆縮型。同じ物理が、制御されれば世界の原子力発電を支えています。なお、この箱では時おり中性子がひとりでに生まれます(自発核分裂や宇宙線による背景中性子)。使い切った核はしばらくすると周囲の燃料から補充され、描画の都合で中性子は220個が上限 — 超臨界の指数増加はグラフ上端の点線で頭打ちになります。',
   },
   en: {
     back: '← Lab',
     label: 'Lab 14 — Nuclear Physics',
     title: 'The Fission Chain Reaction',
     intro:
-      'A neutron striking a heavy nucleus (²³⁵U or ²³⁹Pu) can trigger fission: the nucleus splits into two fragments, spits out a few fresh neutrons, and releases an enormous amount of energy, e.g. ²³⁵U + n gives ¹⁴¹Ba + ⁹²Kr + 3n + about 200 MeV. If those neutrons strike more nuclei, more fissions follow: a chain reaction. The effective multiplication factor k counts how many next-generation fissions each fission causes on average. k below 1 and the population decays away (subcritical); k equal to 1 and it holds steady (critical, a reactor); k above 1 and it grows exponentially (supercritical, a bomb). Fire a neutron, tune k, and watch the chain reaction play out inside the box.',
+      'A neutron striking a heavy nucleus (²³⁵U or ²³⁹Pu) can trigger fission: the nucleus splits into two fragments and releases an enormous amount of energy along with two or three fresh neutrons — their average is ν̄. For example, ²³⁵U + n → ¹⁴¹Ba + ⁹²Kr + 3n + about 200 MeV. If those neutrons strike more nuclei, more fissions follow: a chain reaction. How many next-generation fissions each fission causes on average is the effective multiplication factor k — ν̄ times the probability that any one neutron goes on to cause a fission. Below 1, the population decays away (subcritical). At exactly 1, it holds steady (critical — the state a reactor runs in). Above 1, it multiplies by k every generation, growing exponentially (supercritical — bomb territory). Fire a neutron, tune k, and watch the chain reaction play out inside the box.',
     hint: 'Push k above 1 and the neutron count runs away exponentially',
     isotopeLabel: 'Isotope',
     kLabel: 'Multiplication factor k',
@@ -61,12 +67,14 @@ const copy = {
     energy: 'Energy released',
     fissions: 'Fissions',
     neutrons: 'Neutrons',
+    chartAria: 'Neutron population over time',
+    chartCeiling: 'max',
     note:
-      'The chain reaction fate comes down to k alone. Below k=1 (subcritical) it decays away on its own; at k=1 (critical) the neutron population holds steady, the normal running state of a nuclear reactor. Above k=1 (supercritical) the population multiplies by k every generation, growing exponentially. The critical mass (bare sphere) is roughly 52 kg for ²³⁵U and 10 kg for ²³⁹Pu, and a neutron reflector shaves both down further. ²³⁸U is "fertile," not fissile: it mostly just captures neutrons instead of splitting, transmuting toward ²³⁹Pu, which is why natural uranium has to be enriched. Most neutrons appear instantly at the moment of fission (prompt), but about 0.65% are delayed by seconds to tens of seconds (delayed neutrons); that lag is exactly what lets a reactor be steered with slow-moving control rods instead of running away. The energy itself comes from a mass defect: the fragments weigh about 0.1% less than the original nucleus, and that missing mass reappears as energy via E=mc². One fission releases about 200 MeV (about 3.2×10⁻¹¹ J); fully fissioning 1 g of ²³⁵U releases about 8×10¹⁰ J, the heat of roughly 2.5 tonnes of coal, or about 17 tonnes of TNT. Hiroshima used a uranium gun-type weapon; Nagasaki used a plutonium implosion device. The very same physics, tamed, is what powers nuclear plants today.',
+      'The critical mass — an unreflected sphere — is roughly 52 kg for ²³⁵U and 10 kg for ²³⁹Pu; wrap it in a neutron reflector and both figures shrink. ²³⁸U is "fertile," not fissile: it mostly just captures neutrons instead of splitting, transmuting toward ²³⁹Pu — which is why natural uranium has to be enriched. Most neutrons appear at the instant of fission (prompt), but about 0.65% arrive seconds to tens of seconds late (delayed neutrons); that lag is exactly what lets a reactor be steered with slow-moving control rods instead of running away. The energy itself is a mass defect: the fragments weigh about 0.1% less than the original nucleus, and the missing mass reappears as energy via E=mc². One fission releases about 200 MeV (about 3.2×10⁻¹¹ J); fully fissioning 1 g of ²³⁵U yields about 8×10¹⁰ J — the heat of roughly 2.5 tonnes of coal, or about 17 tonnes of TNT. Hiroshima used a uranium gun-type weapon; Nagasaki a plutonium implosion device. The very same physics, tamed, powers nuclear plants today. One honest note about the box: stray neutrons occasionally appear on their own (the ambient background of spontaneous fission and cosmic rays), spent nuclei restock from the surrounding fuel after a moment, and the display caps at 220 neutrons — so a supercritical run saturates at the chart\'s dashed ceiling rather than growing forever.',
   },
 } as const;
 const t = copy[lang];
-const info = isotopeInfo[lang];
+const isoTex = isotopeTex[lang];
 ---
 
 <section>
@@ -75,13 +83,10 @@ const info = isotopeInfo[lang];
   <h1 class="page-title mt-2">{t.title}</h1>
   <p class="mt-5 text-[var(--ink-secondary)]">{t.intro}</p>
 
-  <p class="lab-formula" aria-label="Chain reaction multiplication factor">
-    <i>k</i> = ν̄·<i>P</i>(fission | <i>n</i>)
-    &ensp;,&ensp;
-    <i>N</i>(<i>g</i>) = <i>N</i>₀<i>k<sup>g</sup></i>
-    &ensp;,&ensp;
-    <i>E</i> ≈ 200 MeV / fission
-  </p>
+  <Formula
+    label="Chain reaction multiplication factor, generation growth, and energy per fission"
+    tex={String.raw`k = \bar{\nu}\,P(\text{fission}\mid n) \qquad N(g) = N_0\,k^{g} \qquad E \approx 200\ \mathrm{MeV/fission}`}
+  />
 
   <div class="glass mt-8 overflow-hidden">
     <div class="lab-stage">
@@ -89,7 +94,12 @@ const info = isotopeInfo[lang];
       <p class="lab-hint">{t.hint}</p>
     </div>
     <div class="fission-chart-wrap">
-      <canvas id="fission-chart" aria-label="Neutron population over time"></canvas>
+      <canvas
+        id="fission-chart"
+        aria-label={t.chartAria}
+        data-neutrons-label={t.neutrons}
+        data-ceiling-word={t.chartCeiling}
+      ></canvas>
     </div>
 
     <div class="lab-panel">
@@ -98,7 +108,14 @@ const info = isotopeInfo[lang];
         <button type="button" class="lab-chip" data-isotope="pu239">²³⁹Pu</button>
       </div>
       <p class="lab-readout">
-        <span id="fission-isotope-info" data-u235={info.u235} data-pu239={info.pu239}>{info.u235}</span>
+        <span id="fission-isotope-info">
+          <span class="fission-iso-variant" data-variant="u235">
+            <Formula display={false} label="Uranium-235 constants" tex={isoTex.u235} />
+          </span>
+          <span class="fission-iso-variant" data-variant="pu239" hidden>
+            <Formula display={false} label="Plutonium-239 constants" tex={isoTex.pu239} />
+          </span>
+        </span>
       </p>
 
       <div class="lab-meta">
@@ -147,7 +164,7 @@ const info = isotopeInfo[lang];
 </section>
 
 <script>
-  import { createFissionScene, type IsotopeKey, type FissionSnapshot, type Regime } from '../lib/lab/fission';
+  import { createFissionScene, POP_CHART_MAX, type IsotopeKey, type FissionSnapshot, type Regime } from '../lib/lab/fission';
 
   const stage = document.getElementById('fission-stage') as HTMLCanvasElement | null;
   const chart = document.getElementById('fission-chart') as HTMLCanvasElement | null;
@@ -169,6 +186,14 @@ const info = isotopeInfo[lang];
     const fmtEnergy = (mev: number, joules: number) =>
       mev < 1000 ? `${mev.toFixed(0)} MeV` : `${mev.toExponential(2)} MeV (${joules.toExponential(2)} J)`;
 
+    // Localized annotations for the population chart (lang lives in the Astro
+    // layer, so it arrives via data-* attributes on the canvas). The ceiling
+    // tag reads e.g. "上限 220" / "max 220", pinned to the display cap.
+    const chartLabels = {
+      neutrons: chart.dataset.neutronsLabel ?? 'neutrons',
+      ceiling: `${chart.dataset.ceilingWord ?? 'max'} ${POP_CHART_MAX}`,
+    };
+
     const scene = createFissionScene(
       stage,
       chart,
@@ -183,6 +208,7 @@ const info = isotopeInfo[lang];
           regimeEl.style.color = REGIME_COLOR[snap.regime];
         }
       },
+      chartLabels,
     );
 
     const chips = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-isotope]'));
@@ -191,7 +217,10 @@ const info = isotopeInfo[lang];
         chips.forEach((c) => c.classList.toggle('active', c === chip));
         const key = (chip.dataset.isotope === 'pu239' ? 'pu239' : 'u235') as IsotopeKey;
         scene.setIsotope(key);
-        if (infoEl) infoEl.textContent = infoEl.dataset[key] ?? '';
+        // Both isotope read-outs are pre-rendered KaTeX; show the selected one.
+        infoEl?.querySelectorAll<HTMLElement>('.fission-iso-variant').forEach((v) => {
+          v.hidden = v.dataset.variant !== key;
+        });
       });
     });
 

--- a/src/components/Formula.astro
+++ b/src/components/Formula.astro
@@ -1,0 +1,85 @@
+---
+import katex from 'katex';
+import 'katex/dist/katex.min.css';
+
+interface Props {
+  /** KaTeX / LaTeX source. */
+  tex: string;
+  /** Display (block) math when true, inline math when false. */
+  display?: boolean;
+  /** Accessible label for the equation region. */
+  label?: string;
+  /** Extra class names on the wrapper. */
+  class?: string;
+}
+
+const { tex, display = true, label, class: extra = '' } = Astro.props;
+
+const html = katex.renderToString(tex, {
+  displayMode: display,
+  throwOnError: true,
+  output: 'htmlAndMathml',
+  strict: 'ignore',
+  trust: false,
+});
+---
+
+{
+  display ? (
+    <div class={`lab-eq ${extra}`} role="math" aria-label={label} set:html={html} />
+  ) : (
+    <span class={`lab-eq-inline ${extra}`} set:html={html} />
+  )
+}
+
+<style is:global>
+  /* Display equation — framed like a display formula set in a paper,
+     with the site's emerald→gold left rule. */
+  .lab-eq {
+    position: relative;
+    margin-top: 1.4rem;
+    padding: 0.9rem 1.3rem;
+    border-left: 2px solid transparent;
+    border-image: linear-gradient(
+        180deg,
+        var(--accent),
+        color-mix(in srgb, #d9b36c 70%, var(--accent))
+      )
+      1;
+    background: linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--accent) 7%, transparent),
+      transparent 72%
+    );
+    border-radius: 0 8px 8px 0;
+    color: var(--ink-secondary);
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  /* KaTeX defaults to centered display math; the site sets its formulas
+     flush-left like a numbered equation, so override the alignment. */
+  .lab-eq .katex-display {
+    margin: 0;
+    text-align: left;
+  }
+  .lab-eq .katex-display > .katex {
+    text-align: left;
+    white-space: normal;
+  }
+  .lab-eq .katex {
+    color: var(--ink-secondary);
+    font-size: 1.12rem;
+  }
+
+  .lab-eq-inline .katex {
+    color: inherit;
+    font-size: 1em;
+  }
+
+  @media (max-width: 640px) {
+    .lab-eq .katex {
+      font-size: 1rem;
+    }
+  }
+</style>

--- a/src/components/FourierPage.astro
+++ b/src/components/FourierPage.astro
@@ -1,5 +1,6 @@
 ---
 import { getLangFromUrl, getLocalizedPath } from '../i18n/utils';
+import Formula from './Formula.astro';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -8,9 +9,11 @@ const copy = {
     back: '← ラボ',
     label: 'Lab 02 — Signal Processing',
     title: 'フーリエ変換の描画機械',
-    intro:
-      '閉じた図形を周期的な複素信号 z(t) = x(t) + iy(t) とみなして離散フーリエ変換すると、図形は「回転する円（エピサイクル）の連なり」に分解されます。振幅の大きい順に K 個だけ残すと、少ない周波数で形の大部分が再現できることが分かります。マウスやタッチで自分の図形を描くこともできます。',
-    hint: 'キャンバスに直接描くと、その図形を分解します',
+    introBefore:
+      '回転する円を鎖のようにつなぎ、いちばん先の一点をペンにして図形を一筆書きする機械です。種を明かせばフーリエ変換 — 閉じた図形を周期的な複素信号 ',
+    introAfter:
+      ' とみなすと、回転する円（エピサイクル）の連なりに分解できます。振幅の大きい順に K 個だけ残しても、形の大部分はきちんと再現される。スライダーで確かめたら、マウスやタッチで自分の図形も描いてみてください。',
+    hint: 'キャンバスに直接描くと、その図形を分解します。閉じた一筆書きがコツ',
     terms: '円の数',
     presetStar: '星',
     presetHeart: 'ハート',
@@ -22,9 +25,11 @@ const copy = {
     back: '← Lab',
     label: 'Lab 02 — Signal Processing',
     title: 'Fourier Drawing Machine',
-    intro:
-      'Treat a closed shape as a periodic complex signal z(t) = x(t) + iy(t) and take its discrete Fourier transform: the shape decomposes into a chain of rotating circles (epicycles). Keeping only the K largest terms shows how few frequencies carry most of the form. Draw your own shape with mouse or touch.',
-    hint: 'Draw directly on the canvas to decompose your own shape',
+    introBefore:
+      'A machine that draws with a chain of spinning circles, using the very tip as its pen. The secret is the Fourier transform: treat a closed shape as a periodic complex signal ',
+    introAfter:
+      ', and it splits into a chain of rotating circles — epicycles. Keep only the K largest terms, and most of the form still comes through. Try the slider, then draw your own shape with mouse or touch.',
+    hint: 'Draw your own shape right on the canvas — a closed single stroke works best',
     terms: 'Circles',
     presetStar: 'Star',
     presetHeart: 'Heart',
@@ -40,13 +45,18 @@ const t = copy[lang];
   <a href={getLocalizedPath(lang, '/lab')} class="lab-back">{t.back}</a>
   <p class="section-label mt-6">{t.label}</p>
   <h1 class="page-title mt-2">{t.title}</h1>
-  <p class="mt-5 text-[var(--ink-secondary)]">{t.intro}</p>
-
-  <p class="lab-formula" aria-label="Discrete Fourier transform">
-    <i>c<sub>k</sub></i> = (1/<i>N</i>) Σ<sub><i>n</i></sub> <i>z<sub>n</sub></i> e<sup>−2πi<i>kn</i>/<i>N</i></sup>
-    &ensp;,&ensp;
-    <i>z</i>(<i>t</i>) ≈ Σ<sub>top-<i>K</i></sub> <i>c<sub>k</sub></i> e<sup>2πi<i>kt</i></sup>
+  <p class="mt-5 text-[var(--ink-secondary)]">
+    {t.introBefore}<Formula
+      display={false}
+      tex={String.raw`z(t) = x(t) + i\,y(t)`}
+      label="complex signal z of t equals x of t plus i y of t"
+    />{t.introAfter}
   </p>
+
+  <Formula
+    label="Discrete Fourier transform"
+    tex={String.raw`c_k = \dfrac{1}{N}\sum_{n=0}^{N-1} z_n\, e^{-2\pi i k n / N}, \qquad z(t) \approx \sum_{\text{top-}K} c_k\, e^{2\pi i k t}`}
+  />
 
   <div class="glass mt-8 overflow-hidden">
     <div class="lab-stage">
@@ -102,10 +112,16 @@ const t = copy[lang];
       activate(drawnChip);
     });
     machine.setPreset('star');
+    slider.max = String(machine.maxTerms);
 
     chips.forEach((chip) => {
       chip.addEventListener('click', () => {
         const preset = chip.dataset.preset;
+        if (preset === 'drawn') {
+          // Restore the last hand-drawn shape instead of a preset.
+          if (machine.restoreDrawn()) activate(chip);
+          return;
+        }
         if (preset && preset in PRESETS) {
           machine.setPreset(preset as keyof typeof PRESETS);
           activate(chip);

--- a/src/components/FusionPage.astro
+++ b/src/components/FusionPage.astro
@@ -1,5 +1,6 @@
 ---
 import { getLangFromUrl, getLocalizedPath } from '../i18n/utils';
+import Formula from './Formula.astro';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -9,8 +10,8 @@ const copy = {
     label: 'Lab 13 — Nuclear Physics',
     title: '核融合とクーロン障壁',
     intro:
-      '2つの軽い原子核は、短距離で働く強い力が引き合わせてくれる前に、まずクーロン力で反発し合います — クーロン障壁 V(r) = 1.44·Z₁Z₂/r MeV。古典力学なら、核はこの障壁の頂上を超えるだけの運動エネルギーを持っていない限り融合できません。しかし量子力学では、トンネル効果のページとまったく同じ理屈で、ガモフ因子 P = exp(−√(E_G/E)) が、古典的には届かないはずのエネルギーでも一定の確率ですり抜けさせてくれます。反応を選び、温度（＝運動エネルギー）を上げてみてください — まれなトンネル成功が、やがて障壁を悠々と越える古典的な衝突に置き換わっていきます。',
-    hint: 'T を上げるとトンネル成功が増える。さらに上げると障壁を古典的に越える',
+      '2つの軽い原子核は、短距離で働く強い力が引き合わせてくれる前に、まずクーロン力で反発し合います。画面の火山のような山がその反発の壁 — クーロン障壁 V(r) = 1.44·Z₁Z₂/r MeV — で、2つの核は左右からこの山を登っていきます。古典力学では、頂上を越えるだけの運動エネルギーがなければ融合できません。しかし量子力学は違います。トンネル効果のページと同じ理屈で、ガモフ因子 P = exp(−√(E_G/E)) の確率なら、届かないはずの高さでも壁をすり抜けられるのです。反応を選び、温度（＝運動エネルギー）を上げてみてください。まれなトンネル成功が、やがて障壁を悠々と越える古典的な衝突に置き換わっていきます。',
+    hint: 'T を上げるとトンネル成功が増え、さらに上げると古典的に障壁を越える（p–p は越えてもほぼ融合しない — 弱い力がボトルネック）',
     reaction: '反応',
     temp: '温度',
     energy: '放出エネルギー',
@@ -19,15 +20,15 @@ const copy = {
     tunnel: 'トンネル確率',
     count: '融合回数',
     classical: '≈1（古典的に通過）',
-    note: 'D–T 融合はわずか 0.018884 u（陽子1個の質量の約2%）を、E = Δm·c² = Δm × 931.494 MeV/u によって 17.59 MeV に変えます。核子あたりの結合エネルギーは ⁵⁶Fe / ⁶²Ni 付近（約8.8 MeV/核子）でピークになり、軽い核はそのピークに向かって融合することで、重い核はそのピークに向かって分裂することでエネルギーを放出します — 核融合と核分裂は同じ1本の曲線を両端から読んでいるだけです。燃料は水（重水素）とリチウムから作れるほど豊富で、灰はヘリウムだけ（長寿命の放射性廃棄物が出ません）。難しいのはクーロン障壁と「閉じ込め」— ITER のようなトカマクは D–T 反応を約1億5000万ケルビンで狙っています。実験炉のプラズマはおよそ 10–20 keV（≈1–2×10⁸ K）ですが、太陽の中心はそれよりずっと「冷たい」1.3 keV（1.5×10⁷ K）しかなく、1個の陽子が p–p 反応を起こすまで平均で数十億年も待つことになります。トンネル確率だけならゼロではありませんが、最初の一歩 p + p → d + e⁺ + ν が弱い力を介するため、実際にはさらに桁違いに稀です。太陽も水素爆弾も、同じ反応をまったく違う速さで走らせているだけなのです。',
+    note: 'D–T 融合はわずか 0.018884 u（陽子1個の質量の約2%）を、E = Δm·c² = Δm × 931.494 MeV/u によって 17.59 MeV に変えます。核子あたりの結合エネルギーは ⁵⁶Fe / ⁶²Ni 付近（約8.8 MeV/核子）でピークになり、軽い核は融合で、重い核は分裂で、その山頂に向かうことでエネルギーを放出します — 核融合と核分裂は、同じ1本の曲線を両端から読んでいるだけです。燃料は水（重水素）とリチウムから作れるほど豊富で、灰はヘリウム。核分裂のような長寿命の高レベル廃棄物は残りません（中性子が炉壁を放射化する課題は残ります）。難しいのはクーロン障壁と「閉じ込め」です。ITER のようなトカマクは D–T 反応を約1億5000万ケルビン、10–20 keV で狙います。一方、太陽の中心はずっと「冷たい」1.3 keV（1.5×10⁷ K）。そこでは1個の陽子が p–p 反応を起こすまで、平均で数十億年も待ちます。トンネル効果だけならここまで稀にはなりません。最初の一歩 p + p → d + e⁺ + ν が弱い力を介するため、桁違いに遅くなるのです（このページの p–p は、4個の陽子が ⁴He になる連鎖全体をひとつにまとめて描いています）。だからこそ水素爆弾は p–p ではなく、速い D–T を使います。同じ「水素の核融合」でも、太陽と爆弾では走らせている反応が違うのです。',
   },
   en: {
     back: '← Lab',
     label: 'Lab 13 — Nuclear Physics',
     title: 'Nuclear Fusion & the Coulomb Barrier',
     intro:
-      "Two light nuclei repel each other electrostatically â the Coulomb barrier, V(r) = 1.44Â·ZâZâ/r MeV â long before the short-range strong force gets a chance to bind them into something heavier and lower-energy. Classically, colliding nuclei need kinetic energy above that barrier’s peak to fuse. Quantum mechanically, exactly as on the tunneling page, they don’t: the Gamow factor P = exp(ââ(E_G/E)) lets a fraction sneak through even when the classical kinetic energy sits well below the summit. Pick a reaction and turn up the temperature (= kinetic energy) â watch rare tunneling successes give way to a routine climb over the top.",
-    hint: 'Raise T — tunneling succeeds more often, then push past the barrier for a classical crossing',
+      "Two light nuclei repel each other electrostatically long before the short-range strong force can bind them. The volcano-shaped curve on screen is that wall — the Coulomb barrier, V(r) = 1.44·Z₁Z₂/r MeV — and the two glowing nuclei climb it from either side. Classically they need kinetic energy above the summit to fuse. Quantum mechanically they don’t: exactly as on the tunneling page, the Gamow factor P = exp(−√(E_G/E)) lets a fraction sneak through well below the top. Pick a reaction and turn up the temperature (= kinetic energy) — watch rare tunneling successes give way to a routine climb over the summit.",
+    hint: 'Raise T — tunneling succeeds more often, then crosses the barrier classically (p–p crosses yet almost never fuses — the weak force is the bottleneck)',
     reaction: 'Reaction',
     temp: 'Temperature',
     energy: 'Energy released',
@@ -36,7 +37,7 @@ const copy = {
     tunnel: 'Tunneling probability',
     count: 'Fusions',
     classical: '≈1 (classical crossing)',
-    note: 'DâT fusion turns just 0.018884 u of mass â about 2% of a proton â into 17.59 MeV via E = ÎmÂ·cÂ² = Îm Ã 931.494 MeV/u. Binding energy per nucleon peaks near âµâ¶Fe / â¶Â²Ni (~8.8 MeV/nucleon): light nuclei release energy by fusing toward that peak, heavy nuclei by fissioning toward it â fusion and fission are the same curve, read from opposite ends. The fuel (hydrogen isotopes, bred from lithium) is abundant and the ash is just helium â no long-lived radioactive waste. What makes fusion hard is the Coulomb barrier and confinement: tokamaks like ITER target DâT around 150 million kelvin. Reactor plasmas run at roughly 10â20 keV (â1â2Ã10â¸ K); the Sun’s core is a comparatively cool 1.3 keV (1.5Ã10â· K), so a given proton there waits billions of years, on average, for its pâp turn. Barrier tunneling alone would not make it that rare â the actual bottleneck is that the first step, p + p â d + eâº + Î½, also needs the weak force, making it rarer still. The Sun and a hydrogen bomb run on the very same reaction, just at wildly different rates.',
+    note: 'D–T fusion turns just 0.018884 u of mass — about 2% of a proton — into 17.59 MeV via E = Δm·c² = Δm × 931.494 MeV/u. Binding energy per nucleon peaks near ⁵⁶Fe / ⁶²Ni (~8.8 MeV per nucleon): light nuclei climb toward that peak by fusing, heavy nuclei by fissioning — fusion and fission are the same curve, read from opposite ends. The fuel (hydrogen isotopes, bred from seawater and lithium) is abundant and the ash is helium; there is none of fission’s long-lived high-level waste, though neutrons do activate the reactor walls. What makes fusion hard is the Coulomb barrier and confinement: tokamaks like ITER aim to run D–T at about 150 million kelvin, 10–20 keV. The Sun’s core is far cooler — 1.3 keV (1.5×10⁷ K) — so a proton there waits billions of years, on average, for its p–p turn. Tunneling alone wouldn’t make it that rare: the first step, p + p → d + e⁺ + ν, also needs the weak force, which slows it by many orders of magnitude (the p–p option on this page bundles the whole four-proton chain into one event). That is exactly why hydrogen bombs burn fast D–T instead — the Sun and the bomb both fuse hydrogen, but not via the same reaction.',
   },
 } as const;
 const t = copy[lang];
@@ -48,13 +49,10 @@ const t = copy[lang];
   <h1 class="page-title mt-2">{t.title}</h1>
   <p class="mt-5 text-[var(--ink-secondary)]">{t.intro}</p>
 
-  <p class="lab-formula" aria-label="Mass-energy equivalence, Coulomb barrier, Gamow factor">
-    <i>E</i> = Δ<i>m</i>·<i>c</i>² = Δ<i>m</i> × 931.494 MeV/u
-    &ensp;,&ensp;
-    <i>V</i>(<i>r</i>) = 1.44·<i>Z</i>₁<i>Z</i>₂/<i>r</i> MeV
-    &ensp;,&ensp;
-    <i>P</i> = exp(−√(<i>E</i><sub>G</sub>/<i>E</i>))
-  </p>
+  <Formula
+    label="Mass-energy equivalence, Coulomb barrier, Gamow factor"
+    tex={String.raw`E = \Delta m\,c^{2} = \Delta m \times 931.494\ \mathrm{MeV/u} \qquad V(r) = \dfrac{1.44\,Z_1 Z_2}{r\,[\mathrm{fm}]}\ \mathrm{MeV} \qquad P = \exp\!\left(-\sqrt{\dfrac{E_G}{E}}\,\right)`}
+  />
 
   <div class="glass mt-8 overflow-hidden">
     <div class="lab-stage">
@@ -94,7 +92,7 @@ const t = copy[lang];
       <div class="lab-meta">
         <p class="lab-readout">
           <span class="lab-readout-label">{t.barrier}</span>
-          <span id="fusion-barrier-value">V₀ = 0.44 MeV · KE = 0.0150 MeV</span>
+          <span id="fusion-barrier-value">V₀ = 0.44 MeV　／　KE = 0.0150 MeV</span>
         </p>
         <p class="lab-readout">
           <span class="lab-readout-label">{t.tunnel}</span>
@@ -132,7 +130,7 @@ const t = copy[lang];
     const classicalLabel = tunnelValue?.dataset.classical ?? '≈1 (classical crossing)';
 
     // Log-mapped slider: 1–700 keV spans solar-core (~1.3 keV) through
-    // reactor-scale (~10â20 keV) up past every reaction’s classical barrier
+    // reactor-scale (~10–20 keV) up past every reaction’s classical barrier
     // (0.44–0.60 MeV), so the same control reaches both regimes.
     const KEV_MIN = 1;
     const KEV_MAX = 700;
@@ -162,7 +160,7 @@ const t = copy[lang];
       { reaction: reactionKey, keVTemp: sliderToKeV(Number(slider.value)) },
       (u) => {
         if (barrierValue) {
-          barrierValue.textContent = `V₀ = ${u.barrierMeV.toFixed(2)} MeV · KE = ${u.keMeV.toFixed(4)} MeV`;
+          barrierValue.textContent = `V₀ = ${u.barrierMeV.toFixed(2)} MeV　／　KE = ${u.keMeV.toFixed(4)} MeV`;
         }
         if (tunnelValue) {
           tunnelValue.textContent = u.overBarrier ? classicalLabel : `P ≈ ${formatScientific(u.pTunnelRaw)}`;

--- a/src/components/HydrogenPage.astro
+++ b/src/components/HydrogenPage.astro
@@ -1,5 +1,6 @@
 ---
 import { getLangFromUrl, getLocalizedPath } from '../i18n/utils';
+import Formula from './Formula.astro';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -9,7 +10,7 @@ const copy = {
     label: 'Lab 01 — Quantum Mechanics',
     title: '水素原子の電子雲',
     intro:
-      'シュレディンガー方程式を水素原子のクーロンポテンシャルについて解くと、波動関数 ψ が量子数 (n, l, m) ごとに求まります。下の点群は、その確率密度 |ψ|² から実際にサンプリングした 26,000 点 — 電子を観測したとき「そこに見出される」場所の分布です。',
+      'シュレディンガー方程式を、原子核がつくる電気的な引力（クーロンポテンシャル）のもとで解くと、波動関数 ψ が量子数 (n, l, m) の組ごとに求まります。下の点群は、その確率密度 |ψ|² から実際にサンプリングした 26,000 点 — 電子を観測したとき「そこに見出される」場所の分布です。チップで 1s から 4f まで切り替えると、雲のかたちががらりと変わります。',
     hint: 'ドラッグで回転、スクロールで拡大縮小',
     plus: '位相 +',
     minus: '位相 −',
@@ -18,14 +19,14 @@ const copy = {
     isotope: '同位体',
     proton: '陽子',
     neutron: '中性子',
-    note: '緑と金の点群は波動関数の符号（位相）。点は1回の「観測」に対応し、N が増えるほど雲の形＝確率分布がはっきりしていきます。中心の粒が原子核（金＝陽子、灰＝中性子）— ただし縮尺は大幅に誇張していて、実際の核はこの表示の約10万分の1の大きさです。同位体を替えても電子雲がほぼ変わらないことに注目 — 化学的性質が中性子の数に鈍感な理由です（換算質量の補正は 0.03% 以下）。',
+    note: '緑と金の点は波動関数の符号（位相）に対応。点は1回の「観測」で、N が増えるほど雲の形＝確率分布がはっきりしていきます。中心の粒は原子核（金＝陽子、灰＝中性子）。縮尺は大幅に誇張してあり、実際の核はこの表示の約10万分の1の大きさです。同位体を替えても電子雲は変わりません。核が重くなることによる実際のずれも 0.03% 以下で、目に見えないほど — 化学が中性子の数をほとんど気にしないのは、このためです。',
   },
   en: {
     back: '← Lab',
     label: 'Lab 01 — Quantum Mechanics',
     title: 'Hydrogen Electron Clouds',
     intro:
-      'Solving the Schrödinger equation for the Coulomb potential of hydrogen yields wavefunctions ψ indexed by the quantum numbers (n, l, m). The point cloud below is 26,000 samples drawn from the probability density |ψ|² — the distribution of where a measurement would actually find the electron.',
+      'Solve the Schrödinger equation in the electric pull of the nucleus — the Coulomb potential — and you get a wavefunction ψ for each set of quantum numbers (n, l, m). The point cloud below is 26,000 samples drawn from the probability density |ψ|²: the distribution of where a measurement would actually find the electron. Flip through the chips from 1s to 4f and watch the cloud change shape.',
     hint: 'Drag to rotate, scroll to zoom',
     plus: 'phase +',
     minus: 'phase −',
@@ -34,7 +35,7 @@ const copy = {
     isotope: 'Isotope',
     proton: 'proton',
     neutron: 'neutron',
-    note: 'The green/gold points mark the sign (phase) of the wavefunction; each point is one "measurement", and the distribution emerges as N grows. The lump at the center is the nucleus (gold = protons, gray = neutrons) — drawn ~100,000× larger than life. Note that switching isotopes barely changes the cloud: chemistry is nearly blind to neutron count (the reduced-mass correction is under 0.03%).',
+    note: 'Green and gold mark the sign (phase) of the wavefunction. Each point is one "measurement"; as N grows, the shape of the cloud — the probability distribution — comes into focus. The lump at the center is the nucleus (gold = protons, gray = neutrons), drawn about 100,000× larger than life. Switching isotopes leaves the cloud unchanged: the real shift from the heavier nucleus is under 0.03%, far too small to see. That is why chemistry barely notices the neutron count.',
   },
 } as const;
 const t = copy[lang];
@@ -58,11 +59,10 @@ const orbitals = [
   <h1 class="page-title mt-2">{t.title}</h1>
   <p class="mt-5 text-[var(--ink-secondary)]">{t.intro}</p>
 
-  <p class="lab-formula" aria-label="Schrödinger equation">
-    −(ℏ²/2<i>m</i>)∇²ψ − <i>e</i>²/(4πε₀<i>r</i>)·ψ = <i>E</i>ψ &ensp;,&ensp;
-    <i>P</i>(<i>r</i>,θ,φ) = |ψ<sub><i>nlm</i></sub>|² &ensp;,&ensp;
-    <i>E<sub>n</sub></i> = −13.6 eV/<i>n</i>²
-  </p>
+  <Formula
+    label="Schrödinger equation, probability density, and energy levels of hydrogen"
+    tex={String.raw`-\dfrac{\hbar^{2}}{2m}\nabla^{2}\psi \;-\; \dfrac{e^{2}}{4\pi\varepsilon_{0} r}\,\psi = E\psi \qquad P(r,\theta,\varphi) = \bigl|\psi_{nlm}\bigr|^{2} \qquad E_{n} = -\dfrac{13.6\ \mathrm{eV}}{n^{2}}`}
+  />
 
   <div class="glass mt-8 overflow-hidden">
     <div class="lab-stage">
@@ -196,16 +196,19 @@ const orbitals = [
     background: var(--accent);
   }
 
+  /* Swatches track the theme-dependent point/nucleus colors (PALETTE mid stops
+     in scene.ts). light-dark() follows the color-scheme global.css sets for the
+     light, .dark, and OS-follow states alike, so the dots match in every theme. */
   .legend-minus {
-    background: #b8934f;
+    background: light-dark(#82531c, #d9b36c);
   }
 
   .legend-proton {
-    background: #c99a3f;
+    background: light-dark(#b08430, #e6b45a);
   }
 
   .legend-neutron {
-    background: #7e858c;
+    background: light-dark(#6f767d, #8e959c);
   }
 
   .orbital-legend .legend-neutron {

--- a/src/components/IsingPage.astro
+++ b/src/components/IsingPage.astro
@@ -1,5 +1,6 @@
 ---
 import { getLangFromUrl, getLocalizedPath } from '../i18n/utils';
+import Formula from './Formula.astro';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -15,7 +16,7 @@ const copy = {
     fieldLabel: '外部磁場',
     magnet: '磁化',
     randomize: 'ランダム化',
-    note: '磁化 M(t) のグラフは −1（全部↓）から +1（全部↑）。Tc 直下では緑と金の島（磁区・ドメイン）がせめぎ合いながらゆっくり粗大化していきます — 本物の磁石の中でも同じことが起きています。H = 0 のとき、どちらの向きに揃うかは完全に偶然です（自発的対称性の破れ）。',
+    note: '磁化 M(t) のグラフは −1（全部↓）から +1（全部↑）。Tc 直下では緑と金の島（磁区・ドメイン）がせめぎ合いながら、ゆっくり大きく育っていきます — 本物の磁石の中でも同じことが起きています。島の縁がほのかに光っているのは「磁壁」。向きの違うスピンが隣り合って、余分なエネルギーを払っている場所です。H = 0 のとき、どちらの向きに揃うかは完全に偶然です（自発的対称性の破れ）。',
   },
   en: {
     back: '← Lab',
@@ -28,7 +29,7 @@ const copy = {
     fieldLabel: 'External field',
     magnet: 'Magnetization',
     randomize: 'Randomize',
-    note: 'The chart tracks M(t) from −1 (all ↓) to +1 (all ↑). Just below Tc, green and gold islands — magnetic domains — wrestle and slowly coarsen, exactly as inside a real magnet. At H = 0, which orientation wins is pure chance: spontaneous symmetry breaking.',
+    note: 'The chart tracks M(t) from −1 (all ↓) to +1 (all ↑). Just below Tc, green and gold islands — magnetic domains — wrestle and slowly grow, exactly as inside a real magnet. The faint glow along their edges marks the domain walls: the places where opposite spins meet and pay an extra energy cost. At H = 0, which orientation wins is pure chance: spontaneous symmetry breaking.',
   },
 } as const;
 const t = copy[lang];
@@ -40,13 +41,10 @@ const t = copy[lang];
   <h1 class="page-title mt-2">{t.title}</h1>
   <p class="mt-5 text-[var(--ink-secondary)]">{t.intro}</p>
 
-  <p class="lab-formula" aria-label="Ising Hamiltonian">
-    <i>E</i> = −<i>J</i> Σ<sub>⟨<i>ij</i>⟩</sub> <i>s<sub>i</sub>s<sub>j</sub></i> − <i>H</i> Σ<sub><i>i</i></sub> <i>s<sub>i</sub></i>
-    &ensp;,&ensp;
-    <i>P</i>(flip) = min(1, e<sup>−Δ<i>E</i>/<i>T</i></sup>)
-    &ensp;,&ensp;
-    <i>T<sub>c</sub></i> = 2/ln(1+√2) ≈ 2.269
-  </p>
+  <Formula
+    label="Ising Hamiltonian, Metropolis acceptance, and critical temperature"
+    tex={String.raw`E = -J \sum_{\langle ij \rangle} s_i s_j \; - \; H \sum_i s_i \qquad P(\mathrm{flip}) = \min\!\left(1,\; e^{-\Delta E / T}\right) \qquad T_c = \dfrac{2}{\ln\!\left(1 + \sqrt{2}\right)} \approx 2.269`}
+  />
 
   <div class="glass mt-8 overflow-hidden">
     <div class="lab-stage">
@@ -129,10 +127,16 @@ const t = copy[lang];
     height: clamp(300px, 52vw, 420px);
   }
 
-  /* The lattice fills the canvas edge-to-edge; keep the hint legible on it. */
+  /* The lattice fills the canvas edge-to-edge; wrap the hint in a small
+     blurred glass pill so it stays legible over both spin colours. */
   .ising-hint {
-    mix-blend-mode: difference;
-    color: #9a9a9a;
+    color: rgba(255, 255, 255, 0.92);
+    background: rgba(0, 0, 0, 0.28);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    border-radius: 999px;
+    padding: 0.18em 0.7em;
+    text-shadow: 0 1px 6px rgba(0, 0, 0, 0.45);
   }
 
   .ising-chart-wrap {

--- a/src/components/KineticsPage.astro
+++ b/src/components/KineticsPage.astro
@@ -1,5 +1,6 @@
 ---
 import { getLangFromUrl, getLocalizedPath } from '../i18n/utils';
+import Formula from './Formula.astro';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -9,13 +10,13 @@ const copy = {
     label: 'Lab 09 — Chemical Kinetics',
     title: '速度論支配と熱力学支配',
     intro:
-      '反応物 A から2つの生成物への道があります。B へは低い山（活性化エネルギー小）だけど浅い谷、C へは高い山だけど深い谷。240 個の粒子がエネルギー地形の上で熱ゆらぎに揺すられるランジュバン動力学です。低温では、越えられる山が低い方だけなので B に溜まります — 速さが勝負を決める「速度論支配」。高温では両方の山を自由に行き来できるようになり、最後は深い谷 C がボルツマン分布で勝ちます — 安定さが勝負を決める「熱力学支配」。',
+      '反応物 A から2つの生成物への道があります。B への道は山（活性化エネルギー）が低いかわり谷が浅く、C への道は山が高いかわり谷が深い。画面では 240 個の粒子が、熱ゆらぎに揺すられながらこの地形を転がります（ランジュバン動力学）。低温では、越えられるのは低い山だけなので B に溜まります — 速さが勝負を決める「速度論支配」。高温では両方の山を自由に行き来できるようになり、最後は深い谷 C がボルツマン分布で勝ちます — 安定さが勝負を決める「熱力学支配」。',
     hint: '低温で B に溜めてから、温度を上げて C への逆転を見る',
     temp: '温度',
     reset: 'リセット',
     kinetic: 'B（速度論的生成物）',
     thermo: 'C（熱力学的生成物）',
-    note: '具体例：1,3-ブタジエン（CH₂=CH–CH=CH₂）に臭化水素 HBr を1分子付加させると、2つの生成物ができます。B = 1,2-付加体〈3-ブロモ-1-ブテン, CH₂=CH–CHBr–CH₃〉は活性化エネルギーが低く速くできる速度論的生成物。C = 1,4-付加体〈1-ブロモ-2-ブテン, BrCH₂–CH=CH–CH₃〉は二重結合が内部にあって安定な熱力学的生成物。−80 ℃ では約 80 : 20 で B が優勢（速さが勝つ）、+40 ℃ では逆転して約 15 : 85 で C が優勢（安定さが勝つ）。ダイヤモンドが黒鉛より不安定なのに室温で事実上永遠に持つのも、変換の山が高すぎる速度論支配です。「どちらが安定か」と「どちらが速いか」は別の問い、というのがこのページの全部です。',
+    note: '具体例：1,3-ブタジエン（CH₂=CH–CH=CH₂）に臭化水素 HBr を1分子付加させると、2つの生成物ができます。B は 1,2-付加体（3-ブロモ-1-ブテン）。低い山を越えて速くできる、速度論的生成物です。C は 1,4-付加体（1-ブロモ-2-ブテン）。二重結合が鎖の内側にあるぶん安定な、熱力学的生成物です。−80 ℃ では約 80 : 20 で B が優勢（速さが勝つ）、+40 ℃ では逆転して約 15 : 85 で C が優勢（安定さが勝つ）。ダイヤモンドが黒鉛より不安定なのに室温で事実上永遠に持つのも、変換の山が高すぎる速度論支配です。「どちらが安定か」と「どちらが速いか」は別の問い、というのがこのページの全部です。',
   },
   en: {
     back: '← Lab',
@@ -28,7 +29,7 @@ const copy = {
     reset: 'Reset',
     kinetic: 'B (kinetic product)',
     thermo: 'C (thermodynamic product)',
-    note: 'A concrete case: add one HBr to 1,3-butadiene (CH₂=CH–CH=CH₂) and two products appear. B = the 1,2-adduct 〈3-bromo-1-butene, CH₂=CH–CHBr–CH₃〉 forms fast over a low barrier — the kinetic product. C = the 1,4-adduct 〈1-bromo-2-butene, BrCH₂–CH=CH–CH₃〉 is more stable thanks to its internal double bond — the thermodynamic product. At −80 °C the mixture is roughly 80 : 20 in favour of B (speed wins); warm it to +40 °C and it flips to about 15 : 85 in favour of C (stability wins). Diamond outlasting graphite at room temperature despite being the less stable form is the same story: kinetic control behind an impossibly high barrier. “Which is more stable” and “which forms faster” are different questions — that is this whole page.',
+    note: 'A concrete case: add one molecule of HBr to 1,3-butadiene (CH₂=CH–CH=CH₂) and two products appear. B is the 1,2-adduct (3-bromo-1-butene): it forms fast over a low barrier — the kinetic product. C is the 1,4-adduct (1-bromo-2-butene): its double bond sits inside the chain, which makes it the more stable one — the thermodynamic product. At −80 °C the mixture is roughly 80 : 20 in favour of B (speed wins); warm it to +40 °C and it flips to about 15 : 85 in favour of C (stability wins). Diamond is the same story: it is less stable than graphite, yet at room temperature it lasts essentially forever, because the barrier to convert is impossibly high — kinetic control. “Which is more stable” and “which forms faster” are different questions — that is this whole page.',
   },
 } as const;
 const t = copy[lang];
@@ -40,13 +41,10 @@ const t = copy[lang];
   <h1 class="page-title mt-2">{t.title}</h1>
   <p class="mt-5 text-[var(--ink-secondary)]">{t.intro}</p>
 
-  <p class="lab-formula" aria-label="Arrhenius and Boltzmann">
-    <i>k</i> = <i>A</i> e<sup>−<i>E<sub>a</sub></i>/<i>k<sub>B</sub>T</i></sup>
-    &ensp;,&ensp;
-    [C]/[B]<sub>eq</sub> = e<sup>−(Δ<i>E<sub>C</sub></i>−Δ<i>E<sub>B</sub></i>)/<i>k<sub>B</sub>T</i></sup>
-    &ensp;,&ensp;
-    d<i>x</i> = −<i>V</i>′(<i>x</i>)d<i>t</i> + √(2<i>k<sub>B</sub>T</i> d<i>t</i>)·η
-  </p>
+  <Formula
+    label="Arrhenius rate, Boltzmann product ratio, and overdamped Langevin dynamics"
+    tex={String.raw`k = A\,\exp\!\left(-\dfrac{E_{\mathrm{a}}}{k_{\mathrm{B}}T}\right) \qquad \left(\dfrac{[\mathrm{C}]}{[\mathrm{B}]}\right)_{\!\mathrm{eq}} = \exp\!\left(-\dfrac{\Delta E_{\mathrm{C}} - \Delta E_{\mathrm{B}}}{k_{\mathrm{B}}T}\right) \qquad \mathrm{d}x = -V'(x)\,\mathrm{d}t + \sqrt{2k_{\mathrm{B}}T\,\mathrm{d}t}\;\eta`}
+  />
 
   <div class="glass mt-8 overflow-hidden">
     <div class="lab-stage">
@@ -133,8 +131,22 @@ const t = copy[lang];
     margin-right: 0.35em;
   }
 
+  /* Track the canvas gold exactly (viz.ts tokens: dark #d9b36c, light #8f6521)
+     so the swatch matches the curve and beads it indexes. Mirrors isDark()'s
+     precedence: an explicit theme class wins, otherwise the system preference. */
   .kinetics-dot-b {
-    background: #b8934f;
+    background: #d9b36c;
+  }
+  @media (prefers-color-scheme: light) {
+    .kinetics-dot-b {
+      background: #8f6521;
+    }
+  }
+  :global(html.dark) .kinetics-dot-b {
+    background: #d9b36c;
+  }
+  :global(html.light) .kinetics-dot-b {
+    background: #8f6521;
   }
 
   .kinetics-dot-c {

--- a/src/components/MillikanPage.astro
+++ b/src/components/MillikanPage.astro
@@ -1,5 +1,6 @@
 ---
 import { getLangFromUrl, getLocalizedPath } from '../i18n/utils';
+import Formula from './Formula.astro';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -9,7 +10,7 @@ const copy = {
     label: 'Lab 07 — Experiment',
     title: 'ミリカンの油滴実験',
     intro:
-      '1909 年、ミリカンは帯電した油滴を平行板コンデンサの間に浮かべ、電気素量 e を測りました。ここでは油滴の電荷（e の何倍かは伏せてあります）と質量だけが決まっていて、あなたが電圧を調整して重力と電気力を釣り合わせます。静止したら「記録」— 何滴も繰り返すと、測った電荷が e の整数倍にだけ集まっていくのが見えてきます。電荷が連続量ではなく粒であることの、歴史的な発見の追体験です。',
+      '1909 年、ミリカンは帯電した油滴を平行板コンデンサの間に浮かべ、電気素量 e を測りました。ここに浮かぶ油滴は質量が分かっていて、マイナスに帯電しています — 電荷が e の何倍なのかは伏せたまま。電圧を上げると油滴は上向きの電気力を受けるので、重力とちょうど釣り合って静止する電圧を探してください。静止したら「記録する」。何滴も繰り返すと、測った電荷が e の整数倍にだけ集まっていくのが見えてきます。電荷が連続量ではなく粒であることの、歴史的な発見の追体験です。',
     hint: '油滴が緑になったら釣り合い。矢印キーで電圧の微調整ができる',
     voltage: '電圧',
     drift: '油滴の動き',
@@ -17,14 +18,14 @@ const copy = {
     newDrop: '新しい油滴',
     record: '記録する',
     count: '記録数',
-    note: '記録した電荷 q = mgd/V が 1e, 2e, 3e… の線上にだけ並ぶこと — それが「電荷の量子化」です。実際のミリカンの測定値は e = 1.59×10⁻¹⁹ C（空気の粘性係数の誤差でわずかにずれていた）。この功績で 1923 年にノーベル物理学賞を受けています。ここでは油滴の質量は既知としていますが、本物の実験では電場を切って終端速度から質量も測ります。',
+    note: '記録した電荷 q = mgd/V が 1e, 2e, 3e… の線の上にだけ並ぶこと — それが「電荷の量子化」です。ミリカン自身の測定値は e = 1.59×10⁻¹⁹ C。当時使われていた空気の粘りけ（粘性係数）の値が少し不正確で、そのぶんだけ真の値からずれていました。この功績で 1923 年にノーベル物理学賞を受けています。ここでは油滴の質量を既知としていますが、本物の実験では電場を切り、落下の終端速度から質量も測ります。',
   },
   en: {
     back: '← Lab',
     label: 'Lab 07 — Experiment',
     title: "Millikan's Oil-Drop Experiment",
     intro:
-      'In 1909 Millikan suspended charged oil droplets between capacitor plates and measured the elementary charge e. Here the droplet has a hidden charge (some multiple of e) and a known mass — you tune the voltage until the electric force balances gravity. When it hovers, hit “record”. Repeat over many droplets and the measured charges pile up only at integer multiples of e: charge comes in lumps, and you get to rediscover it.',
+      'In 1909 Millikan suspended charged oil droplets between capacitor plates and measured the elementary charge e. The droplet here has a known mass and a negative charge — some hidden multiple of e. Raising the voltage pulls it upward, so hunt for the voltage where the electric force exactly balances gravity. When it hovers, hit “Record”. Repeat over many droplets and the measured charges pile up only at integer multiples of e: charge comes in lumps, and you get to rediscover it.',
     hint: 'The droplet turns green when balanced. Arrow keys fine-tune the voltage',
     voltage: 'Voltage',
     drift: 'Droplet motion',
@@ -32,7 +33,7 @@ const copy = {
     newDrop: 'New droplet',
     record: 'Record',
     count: 'Records',
-    note: 'The recorded charges q = mgd/V land only on the 1e, 2e, 3e… lines — that is charge quantization. Millikan measured e = 1.59×10⁻¹⁹ C (slightly off due to the then-known viscosity of air) and won the 1923 Nobel Prize. Here the droplet mass is given; in the real experiment it is deduced from the fall speed with the field off.',
+    note: 'The recorded charges q = mgd/V land only on the 1e, 2e, 3e… lines — that is charge quantization. Millikan himself measured e = 1.59×10⁻¹⁹ C — slightly off because the accepted value for the viscosity of air was itself in error — and won the 1923 Nobel Prize. Here the droplet mass is given; in the real experiment it is deduced from the fall speed with the field off.',
   },
 } as const;
 const t = copy[lang];
@@ -44,13 +45,10 @@ const t = copy[lang];
   <h1 class="page-title mt-2">{t.title}</h1>
   <p class="mt-5 text-[var(--ink-secondary)]">{t.intro}</p>
 
-  <p class="lab-formula" aria-label="Force balance">
-    <i>qE</i> = <i>qV</i>/<i>d</i> = <i>mg</i>
-    &ensp;⇒&ensp;
-    <i>q</i> = <i>mgd</i>/<i>V</i>
-    &ensp;,&ensp;
-    <i>q</i> = <i>n</i>·<i>e</i>, <i>e</i> = 1.602×10⁻¹⁹ C
-  </p>
+  <Formula
+    label="Force balance"
+    tex={String.raw`qE = \dfrac{qV}{d} = mg \quad\Rightarrow\quad q = \dfrac{mgd}{V}, \qquad q = n\cdot e, \quad e = 1.602\times 10^{-19}\ \mathrm{C}`}
+  />
 
   <div class="glass mt-8 overflow-hidden">
     <div class="lab-stage">

--- a/src/components/MoleculesPage.astro
+++ b/src/components/MoleculesPage.astro
@@ -1,5 +1,6 @@
 ---
 import { getLangFromUrl, getLocalizedPath } from '../i18n/utils';
+import Formula from './Formula.astro';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -9,7 +10,7 @@ const copy = {
     label: 'Lab 06 — Molecular Dynamics',
     title: '分子の熱振動と三態',
     intro:
-      '70 個の粒子が、レナード=ジョーンズ相互作用と弱い重力の下で動く 2D 分子動力学です。使っている「原子」は特定の物質ではなく、LJ ポテンシャルの汎用モデル — このモデルは歴史的にアルゴンなどの希ガスに合わせて作られたもので、ここでは温度を σ・ε をアルゴン基準（ε/k_B = 119.8 K、σ = 3.405 Å）で K に換算して表示します。冷やすと粒子は捕まり合って振動するだけの塊（固体）、温めると滑り合う液体、さらに温めると箱いっぱいの気体になります。水分子の絵は装飾で、実際の水の水素結合は入っていません。',
+      '70 個の粒子が、レナード=ジョーンズ（LJ）相互作用と弱い重力の下で動く 2D 分子動力学です。粒子どうしを結ぶのは「近づきすぎると強く反発し、ほどよい距離では引き合う」というシンプルな力だけ。この「原子」は特定の物質ではない汎用モデルですが、LJ モデルは歴史的にアルゴンなどの希ガスに合わせて作られてきたので、温度はアルゴンの値（ε/k_B = 119.8 K）でケルビンに換算して表示します。2D の玩具模型なので、K の数字はあくまで目安。冷やすと粒子は捕まり合って振動するだけの塊（固体）、温めると滑り合う液体、さらに温めると箱いっぱいの気体になります。水分子の絵は装飾で、実際の水の水素結合は入っていません。',
     hint: '温度で氷→水→水蒸気。境目に止めると二相が共存する',
     temp: '温度',
     reset: 'リセット',
@@ -24,14 +25,15 @@ const copy = {
     solidShort: '固',
     liquidShort: '液',
     gasShort: '気',
-    note: '固体・液体・気体は別の物質ではなく、同じ粒子の「運動の激しさ」と「隣との縁の切れやすさ」の違い。境界温度（この模型では T* ≈ 0.32 で融解、≈ 1.0 で蒸発）にスライダーを止めると、一部が固体・一部が液体のように二相が共存します。断熱モードにすると恒温槽を切り、上からピストンで圧縮できます — 熱の出入りがないので、圧縮した仕事がそのまま温度上昇になり、T·V が一定に保たれます（この 2D 単原子気体は自由度 f=2 なので γ=2、実在の 3D 単原子気体は γ=5/3）。ディーゼルエンジンが燃料に点火できるのも、逆に上昇気流で雲ができるのも、この断熱の加熱・冷却です。',
+    note: '固体・液体・気体は別の物質ではなく、同じ粒子の「運動の激しさ」と「隣との縁の切れやすさ」の違い。境界温度（この模型では融解が T* ≈ 0.32、蒸発が ≈ 1.0）にスライダーを止めると、一部が固体・一部が液体のように二相が共存します。断熱モードにすると恒温槽が切れ、上からピストンで圧縮できます。熱の逃げ場がないので、圧縮した仕事はそのまま温度上昇に変わり、気体では T·V がほぼ一定に保たれます。γ = 2 になるのは、この 2D 単原子気体の自由度が f = 2 だから（実在の 3D 単原子気体は γ = 5/3）。ディーゼルエンジンが火花なしで燃料に点火できるのも、上昇気流が冷えて雲をつくるのも、同じ断熱の加熱・冷却です。',
+    startBaseline: { pre: '（開始 ', post: '）' },
   },
   en: {
     back: '← Lab',
     label: 'Lab 06 — Molecular Dynamics',
     title: 'Thermal Motion & the States of Matter',
     intro:
-      'A 2D molecular-dynamics sandbox: 70 particles moving under a Lennard-Jones interaction and weak gravity. The "atom" here is not a specific substance but the generic LJ model — historically calibrated to noble gases, so we map temperature to Kelvin using argon (ε/k_B = 119.8 K, σ = 3.405 Å). Cool them into a vibrating cluster (solid), warm them into a sloshing liquid, heat them into a gas that fills the box. The water glyph is decorative; real water’s hydrogen bonding is not modelled.',
+      'A 2D molecular-dynamics sandbox: 70 particles moving under a Lennard-Jones interaction and weak gravity. The only force between them is a simple one — strong repulsion when they get too close, gentle attraction at arm’s length. The "atom" is not a specific substance but the generic LJ model; since it was historically calibrated to noble gases, the temperature axis is converted to Kelvin using argon’s ε/k_B = 119.8 K. It is a 2D toy, so read the Kelvin numbers as a rough guide. Cool the particles into a vibrating cluster (solid), warm them into a sloshing liquid, heat them into a gas that fills the box. The water glyph is decorative; real water’s hydrogen bonding is not modelled.',
     hint: 'Temperature drives ice → water → steam. Park it on a boundary for coexistence',
     temp: 'Temperature',
     reset: 'Reset',
@@ -46,7 +48,8 @@ const copy = {
     solidShort: 'S',
     liquidShort: 'L',
     gasShort: 'G',
-    note: 'Solid, liquid and gas are not different substances — just different intensities of motion of the same particles. Park the slider on a boundary temperature (this model melts at T* ≈ 0.32 and boils at ≈ 1.0) and the two phases coexist. Switch to Adiabatic to cut the heat bath and compress the gas from the top: with no heat exchange, the piston’s work goes straight into temperature, keeping T·V constant (this 2D monatomic gas has f = 2 degrees of freedom → γ = 2; a real 3D monatomic gas has γ = 5/3). It is exactly this adiabatic heating that lets a diesel engine ignite its fuel, and the adiabatic cooling of rising air that forms clouds.',
+    note: 'Solid, liquid and gas are not different substances — just different intensities of motion of the same particles. Park the slider on a boundary temperature (this model melts at T* ≈ 0.32 and boils at ≈ 1.0) and the two phases coexist. Switch to Adiabatic to cut the heat bath and compress the box from the top. With nowhere for the heat to go, the piston’s work turns straight into temperature, and in the gas phase T·V stays roughly constant. The exponent comes from degrees of freedom: this 2D monatomic gas has f = 2, so γ = 2 (a real 3D monatomic gas has γ = 5/3). The same adiabatic heating lets a diesel engine ignite fuel without a spark — and the same cooling, in rising air, makes clouds.',
+    startBaseline: { pre: ' (start ', post: ')' },
   },
 } as const;
 const t = copy[lang];
@@ -58,13 +61,10 @@ const t = copy[lang];
   <h1 class="page-title mt-2">{t.title}</h1>
   <p class="mt-5 text-[var(--ink-secondary)]">{t.intro}</p>
 
-  <p class="lab-formula" aria-label="Lennard-Jones and adiabatic law">
-    <i>V</i>(<i>r</i>) = 4ε[(σ/<i>r</i>)¹² − (σ/<i>r</i>)⁶]
-    &ensp;,&ensp;
-    ⟨½<i>mv</i>²⟩ = <i>k<sub>B</sub>T</i>
-    &ensp;,&ensp;
-    <i>TV</i><sup>γ−1</sup> = const &nbsp;(γ = 2 → <i>TV</i> = const)
-  </p>
+  <Formula
+    label="Lennard-Jones potential, 2D equipartition, and the adiabatic law"
+    tex={String.raw`V(r) = 4\varepsilon\left[\left(\dfrac{\sigma}{r}\right)^{12} - \left(\dfrac{\sigma}{r}\right)^{6}\right] \qquad \left\langle \tfrac{1}{2}mv^{2} \right\rangle = k_{\mathrm{B}}T \ (\text{2D}) \qquad T\,V^{\gamma-1} = \mathrm{const} \;\; (\gamma = 2 \;\Rightarrow\; T\,V = \mathrm{const})`}
+  />
 
   <div class="glass mt-8 overflow-hidden">
     <div class="lab-stage">
@@ -72,7 +72,7 @@ const t = copy[lang];
         id="molecules-stage"
         class="lab-canvas molecules-stage"
         aria-label={t.title}
-        data-i18n={JSON.stringify({ phases: t.phases, coexist: t.coexist })}
+        data-i18n={JSON.stringify({ phases: t.phases, coexist: t.coexist, startBaseline: t.startBaseline })}
       ></canvas>
       <p class="lab-hint">{t.hint}</p>
     </div>
@@ -142,6 +142,7 @@ const t = copy[lang];
     const i18n = JSON.parse(stage.dataset.i18n || '{}') as {
       phases: Record<string, string>;
       coexist: Record<string, string>;
+      startBaseline: { pre: string; post: string };
     };
     const sim = createMoleculesSim(stage);
     const tempSlider = document.getElementById('mol-temp') as HTMLInputElement;
@@ -179,12 +180,14 @@ const t = copy[lang];
 
     document.getElementById('mol-reset')?.addEventListener('click', () => sim.reset());
 
-    // Readouts follow the MEASURED temperature, so adiabatic compression shows
-    // the gas actually heating up and (if it crosses a boundary) changing phase.
+    // Readouts follow the render-smoothed temperature (sim.displayT): adiabatic
+    // compression still shows the gas heating up and (if it crosses a boundary)
+    // changing phase, but without the ±12% frame-to-frame jitter of the raw
+    // kinetic-energy estimate that would make the digits and phase label flicker.
     let invariant0: number | null = null;
     const refresh = () => {
       requestAnimationFrame(refresh);
-      const Tm = sim.measuredT;
+      const Tm = sim.displayT;
       const V = sim.volumeFraction;
       if (tempValue) tempValue.textContent = `T* = ${Tm.toFixed(2)}`;
       if (kelvinValue) kelvinValue.textContent = `≈ ${Math.round(kelvin(Tm))} K`;
@@ -199,7 +202,13 @@ const t = copy[lang];
       if (volumeValue) volumeValue.textContent = `V = ${V.toFixed(2)}`;
       if (invariantValue) {
         if (invariant0 === null && Number(compressSlider.value) < 0.02) invariant0 = Tm * V;
-        invariantValue.textContent = `T·V = ${(Tm * V).toFixed(2)}`;
+        const live = (Tm * V).toFixed(2);
+        // Show the captured baseline alongside the live product so the viewer
+        // can check that T·V stays put through an adiabatic compression.
+        invariantValue.textContent =
+          invariant0 === null
+            ? `T·V = ${live}`
+            : `T·V = ${live}${i18n.startBaseline.pre}${invariant0.toFixed(2)}${i18n.startBaseline.post}`;
       }
     };
     refresh();

--- a/src/components/PolarizerPage.astro
+++ b/src/components/PolarizerPage.astro
@@ -1,5 +1,6 @@
 ---
 import { getLangFromUrl, getLocalizedPath } from '../i18n/utils';
+import Formula from './Formula.astro';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -9,20 +10,20 @@ const copy = {
     label: 'Lab 05 — Optics',
     title: '偏光サングラスの物理',
     intro:
-      '偏光サングラスのフィルムは、延伸した PVA にヨウ素を染み込ませたもの。ヨウ素が鎖状に整列して「導線の格子」のように働き、鎖に平行な電場成分は吸収され、垂直な成分だけが通ります。理想的な偏光板を通った光の強度はマルスの法則 I = I₀cos²θ に従います。2枚目（サングラス）を回して強度の変化を見てください。',
+      '偏光サングラスのフィルムは、引き伸ばしたポリビニルアルコール（PVA）にヨウ素を染み込ませたもの。ヨウ素が鎖状に整列して「導線の格子」のように働き、鎖に平行な電場成分は吸収され、垂直な成分だけが通ります。いったん偏光した光が、角度 θ ずれた偏光板をもう1枚通るとき、強度はマルスの法則 I = I₀cos²θ に従って弱まります。2枚目（サングラス）を回して強度の変化を見てください。',
     hint: 'サングラスを 90° にしてから、45° の1枚を間に挟んでみる',
     middle: '45°の偏光板を挟む',
     middleAngle: '中間の角度',
     glassesAngle: 'サングラスの角度',
     output: '透過率',
-    note: '90° に直交させた2枚は光を完全に遮りますが、その間に 45° の1枚を挟むと 12.5% の光が復活します。偏光板は光を「ふるいにかける」のではなく、電場をその軸へ射影し直すからです — 量子力学の測定（射影）の、目で見られる古典アナロジー。水面や路面のぎらつきが水平偏光に偏っているため、サングラスの透過軸は縦になっています。',
+    note: '90° に直交させた2枚は光を完全に遮りますが、その間に 45° の1枚を挟むと 12.5% の光が復活します。偏光板は光を「ふるいにかける」のではなく、電場をその軸へ射影し直すからです — 量子力学の測定（射影）の、目に見える古典アナロジー。水面や路面のぎらつきが水平偏光に偏っているため、サングラスの透過軸は縦になっています。',
   },
   en: {
     back: '← Lab',
     label: 'Lab 05 — Optics',
     title: 'The Physics of Polarized Sunglasses',
     intro:
-      'The film in polarized sunglasses is stretched PVA doped with iodine. The iodine lines up into chains that act like a grid of wires: the E-field component parallel to the chains is absorbed, only the perpendicular component passes. Through an ideal polarizer the intensity follows Malus’s law, I = I₀cos²θ. Rotate the second filter (the sunglasses) and watch the intensity respond.',
+      'The film in polarized sunglasses is stretched polyvinyl alcohol (PVA) doped with iodine. The iodine lines up into chains that act like a grid of wires: the E-field component parallel to the chains is absorbed, only the perpendicular component passes. Once the light is polarized, passing it through another polarizer tilted by θ dims it by Malus’s law, I = I₀cos²θ. Rotate the second filter (the sunglasses) and watch the intensity respond.',
     hint: 'Cross the sunglasses at 90°, then slip a 45° filter in between',
     middle: 'Insert 45° filter',
     middleAngle: 'Middle angle',
@@ -40,10 +41,10 @@ const t = copy[lang];
   <h1 class="page-title mt-2">{t.title}</h1>
   <p class="mt-5 text-[var(--ink-secondary)]">{t.intro}</p>
 
-  <p class="lab-formula" aria-label="Malus's law">
-    <i>I</i> = <i>I</i>₀ cos²θ &ensp;,&ensp;
-    0° + 45° + 90°: (1/2) · cos²45° · cos²45° = 1/8 = 12.5%
-  </p>
+  <Formula
+    label="Malus's law"
+    tex={String.raw`I = I_0 \cos^2\theta \qquad 0^\circ \to 45^\circ \to 90^\circ:\ \dfrac{1}{2}\cdot\cos^2 45^\circ \cdot\cos^2 45^\circ = \dfrac{1}{8} = 12.5\%`}
+  />
 
   <div class="glass mt-8 overflow-hidden">
     <div class="lab-stage">

--- a/src/components/PolymerPage.astro
+++ b/src/components/PolymerPage.astro
@@ -1,5 +1,6 @@
 ---
 import { getLangFromUrl, getLocalizedPath } from '../i18n/utils';
+import Formula from './Formula.astro';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -9,7 +10,7 @@ const copy = {
     label: 'Lab 12 — Polymer Chemistry',
     title: 'ポリプロピレンの重合',
     intro:
-      'プロピレン（CH₂=CH–CH₃）の C=C 二重結合が開いて、次々と鎖につながっていく付加重合です。骨格は –CH₂–CH(CH₃)– の繰り返しになり、横に出るメチル基（CH₃）の並び方＝「タクチシティ（立体規則性）」が材料の性質を決めます。すべて同じ側なら結晶化しやすく丈夫な実用プラスチック（アイソタクチック）、交互ならシンジオタクチック、バラバラだと柔らかいゴム状（アタクチック）。この並びを制御できるようになったこと（チーグラー・ナッタ触媒）が、ノーベル賞級の大発明でした。',
+      'プロピレン（CH₂=CH–CH₃）の C=C 二重結合が開いて、次々と鎖につながっていく付加重合です。骨格は –CH₂–CH(CH₃)– の繰り返しになり、横に出るメチル基（CH₃）の並び方＝「タクチシティ（立体規則性）」が材料の性質を決めます。すべて同じ側に並べば結晶化しやすく、丈夫な実用プラスチックに（アイソタクチック）。きっちり交互なら、こちらも結晶性（シンジオタクチック）。バラバラだと結晶になれず、柔らかいゴム状です（アタクチック）。この並びを自在に操るチーグラー・ナッタ触媒の発明には、ノーベル化学賞が贈られています。',
     hint: 'タクチシティを選ぶと、メチル基の並び方が変わる — 同じ分子式なのに別物になる',
     tacticity: '立体規則性',
     iso: 'アイソタクチック',
@@ -17,14 +18,16 @@ const copy = {
     ata: 'アタクチック',
     reset: '最初から重合',
     units: '繰り返し単位',
-    note: 'まったく同じ組成（プロピレンだけ）から、メチル基の並びだけで硬いプラスチックにも柔らかいゴムにもなる — これが高分子の面白さです。アイソタクチックPPは規則正しい並びのおかげで結晶化し、融点約 160℃、密度は水より軽い（0.90）。容器・繊維・自動車部品に大量に使われています。付加重合なので副生成物が出ず、原子はすべて鎖に取り込まれます（アトムエコノミー100%）。',
+    monomer: 'プロピレン',
+    methyl: 'CH₃',
+    note: 'まったく同じ組成（プロピレンだけ）から、メチル基の並びだけで硬いプラスチックにも柔らかいゴムにもなる — これが高分子の面白さです。アイソタクチックPPは規則正しい並びのおかげで結晶化し、融点は約 160 ℃。密度は 0.90 g/cm³ と水より軽く、容器・繊維・自動車部品に大量に使われています。付加重合なので副生成物が出ず、原子はすべて鎖に取り込まれます（アトムエコノミー100%）。',
   },
   en: {
     back: '← Lab',
     label: 'Lab 12 — Polymer Chemistry',
     title: 'Polymerizing Polypropylene',
     intro:
-      'Addition polymerization: the C=C double bond of propylene (CH₂=CH–CH₃) opens and links monomer after monomer into a chain. The backbone becomes a repeating –CH₂–CH(CH₃)–, and the arrangement of the methyl side groups — the tacticity — decides the material. All on one side gives a strong, crystalline everyday plastic (isotactic); strictly alternating is syndiotactic; random gives a soft gum (atactic). Learning to control that arrangement (Ziegler–Natta catalysis) was a Nobel-winning breakthrough.',
+      "Addition polymerization: the C=C double bond of propylene (CH₂=CH–CH₃) opens and links monomer after monomer into a chain. The backbone becomes a repeating –CH₂–CH(CH₃)–, and the arrangement of the methyl side groups — the tacticity — decides the material. All on one side, and it crystallizes into the strong everyday plastic (isotactic). Strictly alternating also crystallizes (syndiotactic). Random, and it can't crystallize at all — you get a soft gum (atactic). The Ziegler–Natta catalysts that control this arrangement earned a Nobel Prize.",
     hint: 'Pick a tacticity and the methyl groups line up differently — same formula, different material',
     tacticity: 'Tacticity',
     iso: 'Isotactic',
@@ -32,7 +35,9 @@ const copy = {
     ata: 'Atactic',
     reset: 'Polymerize again',
     units: 'Repeat units',
-    note: 'From the exact same composition (just propylene), the methyl arrangement alone turns it into a hard plastic or a soft gum — the essence of polymer science. Isotactic PP crystallizes thanks to its regular order: melting point ~160 °C, density 0.90 (lighter than water). It fills containers, fibers, and car parts. Being addition polymerization, no byproduct forms — every atom ends up in the chain (100% atom economy).',
+    monomer: 'propylene',
+    methyl: 'CH₃',
+    note: "From the exact same composition (just propylene), the methyl arrangement alone turns it into a hard plastic or a soft gum — the essence of polymer science. Isotactic PP crystallizes thanks to its regular order: it melts around 160 °C and, at 0.90 g/cm³, floats on water. It fills containers, fibers, and car parts. Being addition polymerization, no byproduct forms — every atom ends up in the chain (100% atom economy).",
   },
 } as const;
 const t = copy[lang];
@@ -44,13 +49,20 @@ const t = copy[lang];
   <h1 class="page-title mt-2">{t.title}</h1>
   <p class="mt-5 text-[var(--ink-secondary)]">{t.intro}</p>
 
-  <p class="lab-formula" aria-label="Polymerization of propylene">
-    <i>n</i> CH₂=CH(CH₃) &nbsp;→&nbsp; –[ CH₂–CH(CH₃) ]<sub><i>n</i></sub>–
-  </p>
+  <Formula
+    label="Polymerization of propylene"
+    tex={String.raw`n\,\mathrm{CH_2{=}CH(CH_3)} \;\longrightarrow\; {-}\!\left[\,\mathrm{CH_2{-}CH(CH_3)}\,\right]_{n}\!{-}`}
+  />
 
   <div class="glass mt-8 overflow-hidden">
     <div class="lab-stage">
-      <canvas id="polymer-canvas" class="lab-canvas" aria-label={t.title}></canvas>
+      <canvas
+        id="polymer-canvas"
+        class="lab-canvas"
+        aria-label={t.title}
+        data-monomer={t.monomer}
+        data-methyl={t.methyl}
+      ></canvas>
       <p class="lab-hint">{t.hint}</p>
     </div>
 
@@ -81,9 +93,13 @@ const t = copy[lang];
   const canvas = document.getElementById('polymer-canvas') as HTMLCanvasElement | null;
   if (canvas) {
     const unitsEl = document.getElementById('polymer-units');
-    const scene = createPolymerScene(canvas, (units) => {
-      if (unitsEl) unitsEl.textContent = `n = ${units}`;
-    });
+    const scene = createPolymerScene(
+      canvas,
+      (units) => {
+        if (unitsEl) unitsEl.textContent = `n = ${units}`;
+      },
+      { monomer: canvas.dataset.monomer ?? 'propylene', methyl: canvas.dataset.methyl ?? 'CH₃' },
+    );
 
     const chips = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-tac]'));
     chips.forEach((chip) => {

--- a/src/components/TunnelPage.astro
+++ b/src/components/TunnelPage.astro
@@ -1,5 +1,6 @@
 ---
 import { getLangFromUrl, getLocalizedPath } from '../i18n/utils';
+import Formula from './Formula.astro';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -9,28 +10,34 @@ const copy = {
     label: 'Lab 08 — Quantum Mechanics',
     title: 'トンネル効果',
     intro:
-      '時間依存シュレディンガー方程式をスプリットステップ・フーリエ法で数値的に解いています（1,024 格子点、各ステップは厳密にユニタリ）。エネルギー E のガウス波束が高さ V₀ の壁に衝突すると、古典力学では V₀ > E なら 100% 跳ね返るはずが、量子力学では壁の中を「染み込んで」反対側に抜ける成分が現れます。透過率 T が衝突の間にリアルタイムで積み上がっていくのを見てください。',
+      '高さ V₀ の壁に、エネルギー E のガウス波束 — 量子力学が描く粒子の姿 — が衝突します。古典力学なら V₀ > E で 100% 跳ね返るはず。ところが量子力学では、壁の中を「染み込んで」反対側へ抜ける成分が現れます。衝突のあいだ、透過率 T がリアルタイムで積み上がっていくのを見てください。裏側では時間依存シュレディンガー方程式をスプリットステップ・フーリエ法で数値的に解いています（1,024 格子点。各ステップで確率の合計が厳密に 100% に保たれる、ユニタリな計算です）。',
     hint: '壁を E より高くしても T が 0 にならないのがトンネル効果',
     height: '壁の高さ',
     width: '壁の幅',
     restart: 'もう一度',
     trans: '透過 T',
     refl: '反射 R',
-    note: 'トンネル効果は実在の現象です — 太陽の核融合（陽子同士がクーロン障壁を抜ける）、フラッシュメモリの書き込み、走査型トンネル顕微鏡（STM）、α崩壊はすべてこれで動いています。透過率は壁の幅と √(V₀−E) に対して指数関数的に落ちる（T ≈ e^(−2κL)）ので、壁をほんの少し厚くするだけで劇的に通れなくなります。',
+    noteBefore:
+      'トンネル効果は実在の現象です — 太陽の核融合（陽子どうしが電気的な反発の壁 = クーロン障壁を抜ける）、フラッシュメモリの書き込み、走査型トンネル顕微鏡（STM）、α崩壊は、すべてこれで動いています。透過率は壁の厚さに対して指数関数的に落ちる（',
+    noteMid: '、κ は ',
+    noteAfter: ' に比例）ので、壁をほんの少し厚くするだけで劇的に通れなくなります。',
   },
   en: {
     back: '← Lab',
     label: 'Lab 08 — Quantum Mechanics',
     title: 'Quantum Tunneling',
     intro:
-      'The time-dependent Schrödinger equation, solved numerically with the split-step Fourier method (1,024 grid points, each step exactly unitary). A gaussian wave packet of energy E hits a barrier of height V₀. Classically, V₀ > E means 100% reflection — but in quantum mechanics part of the packet seeps through the wall and emerges on the far side. Watch the transmission probability T accumulate in real time during the collision.',
+      "A gaussian wave packet — quantum mechanics' portrait of a particle — with energy E slams into a barrier of height V₀. Classically, V₀ > E means 100% reflection. But in quantum mechanics, part of the packet seeps through the wall and emerges on the far side. Watch the transmission probability T accumulate in real time during the collision. Under the hood, the time-dependent Schrödinger equation is solved with the split-step Fourier method — 1,024 grid points, every step keeping total probability at exactly 100% (exactly unitary).",
     hint: 'Raise the wall above E — T still refuses to hit zero. That is tunneling',
     height: 'Barrier height',
     width: 'Barrier width',
     restart: 'Run again',
     trans: 'Transmitted T',
     refl: 'Reflected R',
-    note: 'Tunneling is everywhere: solar fusion (protons crossing the Coulomb barrier), flash-memory writes, scanning tunneling microscopes, alpha decay. Transmission falls exponentially with barrier width and √(V₀−E) — T ≈ e^(−2κL) — so a slightly thicker wall becomes dramatically harder to cross.',
+    noteBefore:
+      'Tunneling is everywhere: solar fusion (protons crossing the Coulomb barrier — the wall of their electric repulsion), flash-memory writes, scanning tunneling microscopes, alpha decay. Transmission falls exponentially with barrier thickness — ',
+    noteMid: ', with κ growing like ',
+    noteAfter: ' — so a slightly thicker wall becomes dramatically harder to cross.',
   },
 } as const;
 const t = copy[lang];
@@ -42,11 +49,10 @@ const t = copy[lang];
   <h1 class="page-title mt-2">{t.title}</h1>
   <p class="mt-5 text-[var(--ink-secondary)]">{t.intro}</p>
 
-  <p class="lab-formula" aria-label="Time-dependent Schrödinger equation">
-    iℏ ∂ψ/∂<i>t</i> = −(ℏ²/2<i>m</i>) ∂²ψ/∂<i>x</i>² + <i>V</i>(<i>x</i>)ψ
-    &ensp;,&ensp;
-    <i>T</i> ≈ e<sup>−2κ<i>L</i></sup>, κ = √(2<i>m</i>(<i>V</i>₀−<i>E</i>))/ℏ
-  </p>
+  <Formula
+    label="Time-dependent Schrödinger equation"
+    tex={String.raw`i\hbar\,\frac{\partial \psi}{\partial t} = -\frac{\hbar^2}{2m}\,\frac{\partial^2 \psi}{\partial x^2} + V(x)\,\psi \qquad T \approx e^{-2\kappa L}, \quad \kappa = \frac{\sqrt{2m(V_0 - E)}}{\hbar}`}
+  />
 
   <div class="glass mt-8 overflow-hidden">
     <div class="lab-stage">
@@ -83,7 +89,17 @@ const t = copy[lang];
     </div>
   </div>
 
-  <p class="mt-5 text-sm text-[var(--ink-muted)]">{t.note}</p>
+  <p class="mt-5 text-sm text-[var(--ink-muted)]">
+    {t.noteBefore}<Formula
+      display={false}
+      tex={String.raw`T \approx e^{-2\kappa L}`}
+      label="transmission probability approximately e to the minus two kappa L"
+    />{t.noteMid}<Formula
+      display={false}
+      tex={String.raw`\sqrt{V_0 - E}`}
+      label="square root of V naught minus E"
+    />{t.noteAfter}
+  </p>
 </section>
 
 <script>

--- a/src/components/WellPage.astro
+++ b/src/components/WellPage.astro
@@ -1,5 +1,6 @@
 ---
 import { getLangFromUrl, getLocalizedPath } from '../i18n/utils';
+import Formula from './Formula.astro';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -9,30 +10,30 @@ const copy = {
     label: 'Lab 10 — Quantum Mechanics',
     title: '井戸型ポテンシャル（箱の中の粒子）',
     intro:
-      'シュレディンガー方程式で最初に解く定番が、これ — 幅 L の「箱」に閉じ込められた粒子です。壁の間にぴったり収まる定在波だけが許されるので、波動関数は ψ_n(x) = √(2/L)·sin(nπx/L)、エネルギーは E_n = n²π²ℏ²/2mL² と飛び飛び（量子化）になります。ギターの弦が特定の倍音しか鳴らせないのと同じ理屈で、電子のエネルギーが連続でなく段々になる理由がここにあります。',
-    hint: '準位を選び、箱の幅を変える。狭くするほど全準位が 1/L² で跳ね上がる',
+      'シュレディンガー方程式で最初に解く定番が、これ — 幅 L の「箱」に閉じ込められた粒子です。量子力学では粒子は波でもあるため、壁の間にぴったり収まる定在波しか存在できず、エネルギーは飛び飛びの値（量子化）に限られます。具体的な形はすぐ下の式のとおり。ギターの弦が特定の倍音しか鳴らせないのと同じ理屈で、電子のエネルギーが連続でなく段々になる理由がここにあります。',
+    hint: '準位を選び、箱の幅を変える。狭くするほど全準位が 1/L² で跳ね上がる（E は L = 1 の基底状態を 1 とした値）',
     level: '準位 n',
     width: '箱の幅 L',
     energy: 'エネルギー',
     mode: '表示',
     modePsi: '波動関数 ψ',
     modeProb: '確率密度 |ψ|²',
-    note: '3つの発見がここに詰まっています。① エネルギーが飛び飛び（量子化）— 準位の間の値は取れない。② 最低準位 E₁ でもゼロにならない（ゼロ点エネルギー）— 不確定性原理から、閉じ込められた粒子は完全に静止できない。③ 箱を狭めると全エネルギーが 1/L² で上昇 — 半導体量子ドットの色が粒径で変わるのはこのため。n が増えると波の節（腹の境目）が増えるのも見どころです。',
+    note: '3つの発見がここに詰まっています。① エネルギーが飛び飛び（量子化）— 準位の間の値は取れない。② 最低準位 E₁ でもゼロにならない（ゼロ点エネルギー）— 不確定性原理から、閉じ込められた粒子は完全に静止できない。③ 箱を狭めると全エネルギーが 1/L² で上昇 — 半導体量子ドットの色が粒径で変わるのはこのため。n を上げると波の節 — 振幅がゼロのまま動かない点 — が増え、ψ の揺れも速くなります。いっぽう |ψ|² に切り替えると形がぴたりと止まる。時間が経っても確率分布が変わらない「定常状態」です。',
   },
   en: {
     back: '← Lab',
     label: 'Lab 10 — Quantum Mechanics',
     title: 'The Square Well (Particle in a Box)',
     intro:
-      'This is the first problem every quantum course solves: a particle trapped in a box of width L. Only standing waves that fit exactly between the walls are allowed, so the wavefunction is ψ_n(x) = √(2/L)·sin(nπx/L) and the energy is quantized: E_n = n²π²ℏ²/2mL². Just as a guitar string sounds only its harmonics, this is why an electron’s energy comes in discrete rungs rather than a continuum.',
-    hint: 'Pick a level and change the box width — squeeze it and every level shoots up as 1/L²',
+      'This is the first problem every quantum course solves: a particle trapped in a box of width L. In quantum mechanics a particle is also a wave, so only standing waves that fit exactly between the walls can exist — which limits the energy to discrete values (quantization); the exact form is the formula just below. Just as a guitar string sounds only its harmonics, this is why an electron’s energy comes in discrete rungs rather than a continuum.',
+    hint: 'Pick a level and change the box width — squeeze it and every level shoots up as 1/L² (E is in units of the widest box’s ground state)',
     level: 'Level n',
     width: 'Box width L',
     energy: 'Energy',
     mode: 'Show',
     modePsi: 'Wavefunction ψ',
     modeProb: 'Probability |ψ|²',
-    note: 'Three lessons live here. (1) Energy is quantized — no value between the rungs is allowed. (2) Even the ground state E₁ is nonzero (zero-point energy): by the uncertainty principle a confined particle can never be fully at rest. (3) Shrinking the box raises every energy as 1/L² — this is why the color of a semiconductor quantum dot depends on its size. Notice too that higher n means more nodes in the wave.',
+    note: 'Three lessons live here. (1) Energy is quantized — no value between the rungs is allowed. (2) Even the ground state E₁ is nonzero (zero-point energy): by the uncertainty principle a confined particle can never be fully at rest. (3) Shrinking the box raises every energy as 1/L² — this is why the color of a semiconductor quantum dot depends on its size. Notice too that higher n means more nodes — points where the wave stays pinned at zero — and a faster shimmer. Switch to |ψ|² and the shape freezes: a stationary state’s probability distribution never changes.',
   },
 } as const;
 const t = copy[lang];
@@ -44,13 +45,10 @@ const t = copy[lang];
   <h1 class="page-title mt-2">{t.title}</h1>
   <p class="mt-5 text-[var(--ink-secondary)]">{t.intro}</p>
 
-  <p class="lab-formula" aria-label="Infinite square well">
-    ψ<sub><i>n</i></sub>(<i>x</i>) = √(2/<i>L</i>) sin(<i>n</i>π<i>x</i>/<i>L</i>)
-    &ensp;,&ensp;
-    <i>E<sub>n</sub></i> = <i>n</i>²π²ℏ²/2<i>mL</i>²
-    &ensp;,&ensp;
-    <i>n</i> = 1, 2, 3, …
-  </p>
+  <Formula
+    label="Infinite square well eigenstates and energies"
+    tex={String.raw`\psi_n(x) = \sqrt{\dfrac{2}{L}}\,\sin\!\left(\dfrac{n\pi x}{L}\right) \qquad E_n = \dfrac{n^2 \pi^2 \hbar^2}{2mL^2} \qquad n = 1,\, 2,\, 3,\, \dots`}
+  />
 
   <div class="glass mt-8 overflow-hidden">
     <div class="lab-stage">

--- a/src/lib/hydrogen/scene.ts
+++ b/src/lib/hydrogen/scene.ts
@@ -126,6 +126,16 @@ export function createOrbitalScene(
   scene.add(bloomPoints);
   scene.add(corePoints);
 
+  // Draw-order index buffer. Light mode blends the core layer with NormalBlending,
+  // which is order-dependent, so we re-sort the revealed prefix back-to-front by
+  // camera distance each tick (see sortByDepth). Dark mode is additive
+  // (order-independent) and stays in sample order so the cloud accumulates as
+  // scattered single events.
+  const order = new Uint32Array(POINT_COUNT);
+  for (let i = 0; i < POINT_COUNT; i++) order[i] = i;
+  const indexAttr = new THREE.BufferAttribute(order, 1);
+  geometry.setIndex(indexAttr);
+
   // Lighting for the schematic nucleus.
   scene.add(new THREE.AmbientLight(0xffffff, 1.0));
   const keyLight = new THREE.DirectionalLight(0xffffff, 1.5);
@@ -169,8 +179,11 @@ export function createOrbitalScene(
   };
   buildNucleus();
 
-  let signs = new Int8Array(0);
+  let signs: Int8Array<ArrayBufferLike> = new Int8Array(0);
   let radiiNorm = new Float32Array(0); // per-point radius, normalized to [0,1]
+  let positions: Float32Array<ArrayBufferLike> = new Float32Array(0); // world-space xyz, kept for depth sorting
+  const sortDist = new Float32Array(POINT_COUNT); // scratch: squared camera distance per sample
+  let depthSort = false; // true in light mode (order-dependent alpha blending)
 
   const applyTheme = () => {
     const dark = isDark();
@@ -178,6 +191,7 @@ export function createOrbitalScene(
     coreMaterial.opacity = palette.opacity;
     coreMaterial.blending = palette.additive ? THREE.AdditiveBlending : THREE.NormalBlending;
     coreMaterial.needsUpdate = true;
+    depthSort = !palette.additive; // only NormalBlending needs back-to-front ordering
     bloomMaterial.opacity = palette.bloomOpacity;
     bloomMaterial.visible = palette.bloomOpacity > 0;
     protonMaterial.color.set(palette.proton);
@@ -221,6 +235,10 @@ export function createOrbitalScene(
     }
     for (let i = 0; i < signs.length; i++) radiiNorm[i] = Math.min(1, radiiNorm[i] / (rMax * 0.85));
     geometry.setAttribute('position', new THREE.BufferAttribute(samples.positions, 3));
+    positions = samples.positions;
+    // Reset draw order to sample order (identity); light mode re-sorts each tick.
+    for (let i = 0; i < POINT_COUNT; i++) order[i] = i;
+    indexAttr.needsUpdate = true;
     revealed = 0;
     geometry.setDrawRange(0, 0);
     onProgress?.(0, POINT_COUNT);
@@ -244,7 +262,28 @@ export function createOrbitalScene(
   window.addEventListener('resize', resize);
   resize();
 
+  // Back-to-front sort of the revealed prefix by camera distance, so the
+  // order-dependent light-mode blend resolves nearer lobes over farther ones.
+  // Only the first `revealed` slots are touched, so the visible set stays the
+  // first-N samples — reveal semantics are preserved, only draw order changes.
+  const cameraPos = new THREE.Vector3();
+  const sortByDepth = () => {
+    if (!depthSort || revealed < 2) return;
+    camera.getWorldPosition(cameraPos);
+    const { x: cx, y: cy, z: cz } = cameraPos;
+    for (let i = 0; i < revealed; i++) {
+      const j = order[i];
+      const dx = positions[j * 3] - cx;
+      const dy = positions[j * 3 + 1] - cy;
+      const dz = positions[j * 3 + 2] - cz;
+      sortDist[j] = dx * dx + dy * dy + dz * dz;
+    }
+    order.subarray(0, revealed).sort((a, b) => sortDist[b] - sortDist[a]);
+    indexAttr.needsUpdate = true;
+  };
+
   let rafId = 0;
+  let sortTick = 0;
   const loop = () => {
     rafId = requestAnimationFrame(loop);
     if (revealed < POINT_COUNT && signs.length > 0) {
@@ -255,6 +294,9 @@ export function createOrbitalScene(
     nucleus.rotation.y += 0.004;
     nucleus.rotation.x += 0.0017;
     controls.update();
+    // Re-sort every ~12 frames: the auto-rotate drift between ticks is <2°, so
+    // the throttle is imperceptible but keeps the per-frame cost negligible.
+    if (depthSort && ++sortTick % 12 === 0) sortByDepth();
     renderer.render(scene, camera);
   };
   const onVisibility = () => {

--- a/src/lib/lab/chirality.ts
+++ b/src/lib/lab/chirality.ts
@@ -97,9 +97,20 @@ export interface ChiralityScene {
   dispose(): void;
 }
 
+/** Localized captions for the two on-canvas parts of the schematic. Kept out of
+ *  the sim so this module stays i18n-free; the page passes the current-language
+ *  strings in. */
+export interface ChiralityLabels {
+  /** Caption above the receptor cradle (e.g. "受容体" / "Receptor"). */
+  receptor: string;
+  /** Caption above the incoming drug molecule (e.g. "薬" / "Drug"). */
+  drug: string;
+}
+
 export function createChiralityScene(
   canvas: HTMLCanvasElement,
   onUpdate?: (hand: Hand, binds: boolean, matched: number) => void,
+  labels?: ChiralityLabels,
 ): ChiralityScene {
   const ctx = canvas.getContext('2d')!;
   let hand: Hand = 'R';
@@ -305,6 +316,20 @@ export function createChiralityScene(
       ctx.beginPath();
       ctx.arc(gx, gy, r * 0.55, 0, 2 * Math.PI);
       ctx.fill();
+      ctx.restore();
+    }
+
+    // Faint captions so the schematic reads on its own: which arc is the
+    // receptor pocket, which glowing cluster is the incoming drug. Drawn last,
+    // flat (no glow), in muted ink so they never compete with the molecule.
+    if (labels && (labels.receptor || labels.drug)) {
+      ctx.save();
+      ctx.font = '500 11px system-ui, sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'alphabetic';
+      ctx.fillStyle = rgb(colors.bond, colors.dark ? 0.72 : 0.78);
+      if (labels.receptor) ctx.fillText(labels.receptor, pocketX, cy - R * 2.2);
+      if (labels.drug) ctx.fillText(labels.drug, cx, cy - bond * 1.3);
       ctx.restore();
     }
 

--- a/src/lib/lab/entropy.ts
+++ b/src/lib/lab/entropy.ts
@@ -15,6 +15,8 @@ const GRID_X = 16;
 const GRID_Y = 10;
 const SPEED_SIGMA = 0.05; // box widths per second (gaussian components)
 const HISTORY_CAP = 900;
+/** Seconds of simulated time between chart samples. 900 × 1/15 s ≈ 60 s window. */
+const SAMPLE_INTERVAL_S = 1 / 15;
 /** The wall drops on its own after this long — entropy needs no button. */
 const AUTO_RELEASE_S = 3;
 /** Render-only: how long the dropped wall takes to dissolve visually. Does
@@ -251,7 +253,6 @@ export function createEntropySim(
     cctx.lineTo(w, h - pad);
     cctx.stroke();
     cctx.restore();
-    label(cctx, 'S = 1', w - 4, pad + 10, colors.inkMuted, { size: 9, align: 'right', alpha: 0.5 });
 
     if (history.length > 1) {
       const pts = history.map((s, i) => ({
@@ -261,11 +262,23 @@ export function createEntropySim(
       areaFill(cctx, pts, h - pad, colors.green, colors.dark ? 0.3 : 0.16);
       glowStroke(cctx, pts, colors.green, 1.6, colors.dark ? 1 : 0.55, colors.dark);
     }
+
+    // Draw the 'S = 1' label last, over a small transparent knockout — in the
+    // mixed end state S rides right along the dashed line, and the additive
+    // glow would otherwise swallow this 9px caption.
+    cctx.save();
+    cctx.font = '400 9px system-ui, -apple-system, sans-serif';
+    const tw = cctx.measureText('S = 1').width;
+    cctx.clearRect(w - 4 - tw - 3, pad + 1, tw + 6, 13);
+    cctx.restore();
+    label(cctx, 'S = 1', w - 4, pad + 10, colors.inkMuted, { size: 9, align: 'right', alpha: 0.5 });
   };
 
   let rafId = 0;
   let last = performance.now();
-  let frame = 0;
+  /** The chart samples on simulated wall-clock (not frame count) so its ~60 s
+   *  window is identical on 60 Hz and 120 Hz displays. 900 samples × 1/15 s. */
+  let sampleClock = 0;
   const loop = (now: number) => {
     rafId = requestAnimationFrame(loop);
     const dt = Math.min(0.05, (now - last) / 1000);
@@ -278,13 +291,14 @@ export function createEntropySim(
       wallDissolve = Math.max(0, wallDissolve - dt / WALL_DISSOLVE_S);
     }
     step(dt);
-    if (frame % 4 === 0) {
+    sampleClock += dt;
+    if (sampleClock >= SAMPLE_INTERVAL_S) {
+      sampleClock %= SAMPLE_INTERVAL_S;
       mixing = computeMixing();
       if (history.length >= HISTORY_CAP) history.shift();
       history.push(mixing);
       onUpdate?.(mixing, wallUp);
     }
-    frame++;
     drawStage();
     drawChart();
   };

--- a/src/lib/lab/fission.ts
+++ b/src/lib/lab/fission.ts
@@ -239,7 +239,9 @@ function spawnNeutron(
   nuBar: number,
   rng: () => number,
 ) {
-  if (into.length >= MAX_NEUTRONS) return;
+  // No cap check here: a newborn neutron must always be created at its flash
+  // site. The display cap is enforced downstream in step() by evicting the
+  // oldest in-flight neutrons, not by refusing births (see the merge below).
   const pFission = fissionProbability(k, nuBar);
   const targetIdx = rng() < pFission ? randomAliveIndex(nuclei, rng) : -1;
   let vx: number;
@@ -365,16 +367,23 @@ export function createFissionCore(initial: Partial<FissionParams> = {}, rng: () 
         // else: leaked out of the box, lost
       }
 
-      neutrons = survivors.concat(spawned).slice(0, MAX_NEUTRONS);
-
       // Faint ambient background (spontaneous fission / cosmic rays): one
       // stray neutron every AMBIENT_INTERVAL seconds, born inside the
-      // material itself rather than fired in from outside.
+      // material itself rather than fired in from outside. Emitted into the
+      // newborn set so it takes part in the cap eviction below.
       ambientAccum += dt;
       if (ambientAccum >= AMBIENT_INTERVAL) {
         ambientAccum -= AMBIENT_INTERVAL;
-        spawnNeutron(neutrons, nuclei, 0.1 + rng() * 0.8, 0.1 + rng() * 0.8, null, params.k, isotope.nuBar, rng);
+        spawnNeutron(spawned, nuclei, 0.1 + rng() * 0.8, 0.1 + rng() * 0.8, null, params.k, isotope.nuBar, rng);
       }
+
+      // At the display cap, evict the OLDEST in-flight neutrons rather than
+      // dropping newborns: a freshly emitted neutron must always appear at
+      // its flash site, so it is the least visually attributable (oldest)
+      // neutrons that vanish instead. k-in-expectation is unaffected — this
+      // only bites while the population is pinned at MAX_NEUTRONS.
+      const merged = survivors.concat(spawned);
+      neutrons = merged.length > MAX_NEUTRONS ? merged.slice(merged.length - MAX_NEUTRONS) : merged;
 
       sampleAccum += dt;
       if (sampleAccum >= SAMPLE_INTERVAL) {
@@ -475,11 +484,21 @@ export interface FissionScene {
   dispose(): void;
 }
 
+/** Localized captions drawn onto the population strip chart. Optional — the
+ *  chart renders fine without them, just unlabelled. */
+export interface FissionChartLabels {
+  /** caption at top-left, e.g. "中性子数" / "neutrons" */
+  neutrons: string;
+  /** tag on the dashed display-cap line, e.g. "上限 220" / "max 220" */
+  ceiling: string;
+}
+
 export function createFissionScene(
   stage: HTMLCanvasElement,
   chart: HTMLCanvasElement,
   initial: Partial<FissionParams> = {},
   onUpdate?: (snap: FissionSnapshot) => void,
+  chartLabels?: FissionChartLabels,
 ): FissionScene {
   const sctx = stage.getContext('2d')!;
   const cctx = chart.getContext('2d')!;
@@ -630,6 +649,23 @@ export function createFissionScene(
       }));
       areaFill(cctx, pts, h - pad, curveColor, colors.dark ? 0.26 : 0.16);
       glowStroke(cctx, pts, curveColor, 1.6, colors.dark ? 0.8 : 0.4, colors.dark);
+    }
+
+    // Annotate the strip: what it plots (top-left) and the dashed cap it can
+    // saturate against (right-aligned on the ceiling line). Drawn last so the
+    // captions read cleanly over the curve.
+    if (chartLabels) {
+      label(cctx, chartLabels.neutrons, 3, pad + 9, colors.inkMuted, {
+        size: 9.5,
+        weight: 500,
+        alpha: colors.dark ? 0.72 : 0.66,
+      });
+      label(cctx, chartLabels.ceiling, w - 3, pad + 9, colors.inkMuted, {
+        size: 9.5,
+        weight: 500,
+        align: 'right',
+        alpha: colors.dark ? 0.58 : 0.52,
+      });
     }
   };
 

--- a/src/lib/lab/fourier.ts
+++ b/src/lib/lab/fourier.ts
@@ -97,6 +97,8 @@ export interface FourierMachine {
   setShape(points: Pt[]): void;
   setPreset(name: keyof typeof PRESETS): void;
   setTerms(k: number): void;
+  /** Re-decompose the last hand-drawn shape; returns false if none exists yet. */
+  restoreDrawn(): boolean;
   readonly maxTerms: number;
   dispose(): void;
 }
@@ -117,6 +119,8 @@ export function createFourierMachine(
   let path: Pt[] = []; // reconstruction with `terms` terms, normalized coords
   /** True once the current shape came from hand-drawn input (colors the trace gold). */
   let drawnSource = false;
+  /** The last hand-drawn shape (resampled), kept so the "drawn" chip can restore it. */
+  let drawnPts: Pt[] | null = null;
 
   // Evaluate the truncated Fourier sum at phase u ∈ [0, 1).
   const evalSum = (u: number, k: number): Pt => {
@@ -136,8 +140,10 @@ export function createFourierMachine(
   };
 
   const setShapeInternal = (points: Pt[], drawn: boolean) => {
-    epicycles = dft(resampleClosed(points, SAMPLES));
+    const sampled = resampleClosed(points, SAMPLES);
+    epicycles = dft(sampled);
     drawnSource = drawn;
+    if (drawn) drawnPts = sampled;
     recomputePath();
   };
 
@@ -250,12 +256,27 @@ export function createFourierMachine(
         }
         glowStroke(ctx, basePts, sampleRamp(curveRamp, 0.4), 1.3, tk.glowAlpha * 0.5, tk.dark);
       }
-      const cometPts: { x: number; y: number }[] = [];
-      for (let i = tail; i <= upto; i++) {
-        const p = path[i];
-        cometPts.push({ x: sx(p), y: sy(p) });
+      // Comet head [tail, upto]: draw in short sub-chunks that share endpoints
+      // and lerp their brightness/width from the tail values up to the head,
+      // so the fade is continuous instead of a single flat step.
+      const COMET_CHUNKS = 8;
+      const span = upto - tail;
+      for (let c = 0; c < COMET_CHUNKS; c++) {
+        const i0 = tail + Math.floor((span * c) / COMET_CHUNKS);
+        const i1 = tail + Math.floor((span * (c + 1)) / COMET_CHUNKS);
+        if (i1 <= i0) continue;
+        const chunk: { x: number; y: number }[] = [];
+        for (let i = i0; i <= i1; i++) {
+          const p = path[i];
+          chunk.push({ x: sx(p), y: sy(p) });
+        }
+        // f runs 0 (tail) → 1 (head) across the comet span.
+        const f = (c + 0.5) / COMET_CHUNKS;
+        const shade = sampleRamp(curveRamp, 0.4 + 0.5 * f);
+        const width = 1.3 + 1.1 * f;
+        const glow = tk.glowAlpha * (0.5 + 0.5 * f);
+        glowStroke(ctx, chunk, shade, width, glow, tk.dark);
       }
-      glowStroke(ctx, cometPts, sampleRamp(curveRamp, 0.9), 2.4, tk.glowAlpha, tk.dark);
     }
 
     // Epicycle chain: barely-there rings + thin, glowing radius vectors.
@@ -295,6 +316,11 @@ export function createFourierMachine(
     setTerms(k) {
       terms = Math.max(1, Math.round(k));
       recomputePath();
+    },
+    restoreDrawn() {
+      if (!drawnPts) return false;
+      setShapeInternal(drawnPts, true);
+      return true;
     },
     get maxTerms() {
       return SAMPLES;

--- a/src/lib/lab/fusion.ts
+++ b/src/lib/lab/fusion.ts
@@ -614,16 +614,23 @@ export function createFusionScene(
       alpha: 0.75,
     });
 
-    const keY = yFor(keMeV);
-    ctx.save();
-    ctx.strokeStyle = rgb(tk.inkMuted, tk.dark ? 0.45 : 0.55);
-    ctx.setLineDash([2, 4]);
-    ctx.lineWidth = 1;
-    ctx.beginPath();
-    ctx.moveTo(0, keY);
-    ctx.lineTo(w, keY);
-    ctx.stroke();
-    ctx.restore();
+    // Clamp the KE reference to a minimum offset above the baseline so it never
+    // vanishes into the baseline hairline at very low T (1 keV → ~0.4 px), and
+    // drop the dashed line (keep only the label) when the true line would sit
+    // within 2 px of the baseline — otherwise it just thickens the hairline.
+    const keYraw = yFor(keMeV);
+    const keY = Math.min(keYraw, baseline - 3);
+    if (baseline - keYraw > 2) {
+      ctx.save();
+      ctx.strokeStyle = rgb(tk.inkMuted, tk.dark ? 0.45 : 0.55);
+      ctx.setLineDash([2, 4]);
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(0, keY);
+      ctx.lineTo(w, keY);
+      ctx.stroke();
+      ctx.restore();
+    }
     label(ctx, 'KE', 8, keY - 6, tk.inkMuted, { size: 10, alpha: 0.8 });
 
     // ——— the two traveling nuclei ———
@@ -707,6 +714,33 @@ export function createFusionScene(
     ctx.moveTo(0, baseline);
     ctx.lineTo(w, baseline);
     ctx.stroke();
+
+    // ——— axis captions + log-r ticks ———
+    // Name the two axes so the "the mountain IS V(r)" metaphor is stated
+    // visually: height is potential energy, the horizontal spread is the log
+    // internuclear separation (both nuclei sit at ±r/2, so r reads symmetric
+    // about the fused center at cx). Faint ticks mark the decades of r.
+    ctx.save();
+    ctx.setLineDash([]);
+    ctx.strokeStyle = rgb(tk.inkMuted, tk.dark ? 0.3 : 0.4);
+    ctx.lineWidth = 1;
+    for (const rFm of [10, 100, 1000]) {
+      const off = xFor(uOfR(rFm));
+      for (const sx of [cx + off, cx - off]) {
+        ctx.beginPath();
+        ctx.moveTo(sx, baseline);
+        ctx.lineTo(sx, baseline + 4);
+        ctx.stroke();
+      }
+      label(ctx, String(rFm), cx + off, baseline + 14, tk.inkMuted, {
+        size: 9,
+        align: 'center',
+        alpha: 0.5,
+      });
+    }
+    ctx.restore();
+    label(ctx, 'r (fm, log)', w - 8, baseline - 6, tk.inkMuted, { size: 9, align: 'right', alpha: 0.55 });
+    label(ctx, 'V (MeV)', 8, 14, tk.inkMuted, { size: 9, alpha: 0.55 });
 
     onUpdate?.({
       barrierMeV: reaction.barrierMeV,

--- a/src/lib/lab/ising.ts
+++ b/src/lib/lab/ising.ts
@@ -184,14 +184,25 @@ export function createIsingSim(
     sctx.imageSmoothingEnabled = true;
     sctx.imageSmoothingQuality = 'high';
     sctx.clearRect(0, 0, stage.width, stage.height);
-    sctx.drawImage(fieldMid2, 0, 0, stage.width, stage.height);
+
+    // Cover-fit the lattice into the stage so cells stay square whatever the
+    // canvas aspect is — otherwise a tall mobile canvas stretches the
+    // statistically isotropic domains into vertical blobs. Periodic
+    // boundaries make the cropped edge cells free of visible seams.
+    const scale = Math.max(stage.width / fieldMid2.width, stage.height / fieldMid2.height);
+    const dw = fieldMid2.width * scale;
+    const dh = fieldMid2.height * scale;
+    const dx = (stage.width - dw) / 2;
+    const dy = (stage.height - dh) / 2;
+    sctx.drawImage(fieldMid2, dx, dy, dw, dh);
 
     // A single soft (bilinear) pass for the wall glow, composited additively
-    // in dark mode — a faint luminous film over every domain boundary.
+    // in dark mode — a faint luminous film over every domain boundary. Same
+    // destination rect as the field so the seams stay registered.
     sctx.save();
     sctx.globalCompositeOperation = colors.blend;
     sctx.globalAlpha = colors.glowAlpha * 0.55;
-    sctx.drawImage(wallOff, 0, 0, stage.width, stage.height);
+    sctx.drawImage(wallOff, dx, dy, dw, dh);
     sctx.restore();
   };
 
@@ -221,6 +232,14 @@ export function createIsingSim(
     cctx.moveTo(0, midY);
     cctx.lineTo(w, midY);
     cctx.stroke();
+
+    // Micro-labels so the chart is self-describing: M runs +1 (all ↑) at the
+    // top to −1 (all ↓) at the bottom. Left-aligned inside the pad so they
+    // never collide with the curve's leading edge on the right.
+    cctx.fillStyle = rgb(colors.inkMuted, colors.dark ? 0.5 : 0.55);
+    cctx.font = '9px ui-sans-serif, system-ui';
+    cctx.fillText('+1', 4, pad + 9);
+    cctx.fillText('−1', 4, h - pad - 3);
     cctx.restore();
 
     if (history.length > 1) {

--- a/src/lib/lab/kinetics.ts
+++ b/src/lib/lab/kinetics.ts
@@ -155,11 +155,23 @@ export function createKineticsScene(
   let historyB: number[] = [];
   let historyC: number[] = [];
 
+  // Offscreen buffer that holds ONLY the beads. It is the only layer that gets
+  // faded for motion trails; the static landscape is redrawn fresh on the stage
+  // each frame and composited over it — so the valley fills, curve, and labels
+  // render at exactly their authored alpha instead of accumulating a trail gain.
+  const trail = document.createElement('canvas');
+  const tctx = trail.getContext('2d')!;
+  const clearTrail = () => {
+    tctx.setTransform(1, 0, 0, 1, 0, 0);
+    tctx.clearRect(0, 0, trail.width, trail.height);
+  };
+
   const themeObserver = new MutationObserver(() => {
     colors = themeColors();
     goldSprite = tintSprite(colors.gold);
     greenSprite = tintSprite(colors.green);
     neutralSprite = tintSprite(colors.inkMuted);
+    clearTrail(); // drop trails tinted for the old theme
   });
   themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
 
@@ -169,6 +181,9 @@ export function createKineticsScene(
       c.width = Math.max(1, Math.round(c.clientWidth * dpr));
       c.height = Math.max(1, Math.round(c.clientHeight * dpr));
     }
+    // Match the bead buffer to the stage backing store (this also clears it).
+    trail.width = stage.width;
+    trail.height = stage.height;
   };
   const resizeObserver = new ResizeObserver(resize);
   resizeObserver.observe(stage);
@@ -180,15 +195,48 @@ export function createKineticsScene(
     const dpr = Math.min(window.devicePixelRatio, 2);
     const w = stage.width / dpr;
     const h = stage.height / dpr;
-    sctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-
-    // Afterimage trails: beads leave a faint hop-trail as they cross the
-    // barriers. The curve and labels are redrawn at full strength every
-    // frame, so only the moving beads ever visibly smear.
-    fadeTrails(sctx, w, h, colors.dark ? 0.3 : 0.42);
 
     const sx = (x: number) => ((x + 1.15) / 2.3) * w;
     const sy = (v: number) => h * 0.12 + ((0.85 - v) / 1.8) * h * 0.78;
+
+    // --- Bead buffer: the only layer that keeps afterimage trails. ---
+    // Count each well's current population first so a dense pile can share out
+    // its glow instead of every bead firing at full additive alpha.
+    const { xs } = core;
+    let cntB = 0;
+    let cntC = 0;
+    for (let i = 0; i < xs.length; i++) {
+      if (xs[i] < -0.4) cntB++;
+      else if (xs[i] > 0.4) cntC++;
+    }
+
+    tctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    fadeTrails(tctx, w, h, colors.dark ? 0.3 : 0.42);
+    const dot = 10.5;
+    tctx.save();
+    tctx.globalCompositeOperation = colors.blend;
+    for (let i = 0; i < xs.length; i++) {
+      const x = xs[i];
+      const inB = x < -0.4;
+      const inC = x > 0.4;
+      const sprite = inB ? goldSprite : inC ? greenSprite : neutralSprite;
+      // Density-aware alpha: small piles keep the full glow; a full well drops
+      // each bead's additive alpha so the core stays recognisably gold/green
+      // rather than saturating to white (min caps the boost at 1).
+      const inWell = inB || inC;
+      const base = inWell ? colors.glowAlpha : colors.glowAlpha * 0.55;
+      tctx.globalAlpha = inWell ? base * Math.min(1, 14 / (inB ? cntB : cntC)) : base;
+      const jx = (((i * 53) % 15) - 7) * 0.35;
+      const jy = ((i * 29) % 13) * 0.9;
+      const bx = sx(x) + jx;
+      const by = sy(potential(x)) - 4 - jy;
+      tctx.drawImage(sprite, bx - dot / 2, by - dot / 2, dot, dot);
+    }
+    tctx.restore();
+
+    // --- Stage: static landscape, redrawn fresh at its authored alpha. ---
+    sctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    sctx.clearRect(0, 0, w, h);
 
     // Landscape curve, sampled once and reused for the stroke + well fills.
     const SAMPLES = 240;
@@ -210,6 +258,35 @@ export function createKineticsScene(
 
     glowStroke(sctx, curvePts, colors.inkMuted, 1.6, colors.dark ? 0.8 : 0.4, colors.dark);
 
+    // Activation-energy sticks: a whisper-quiet dashed riser from the reactant
+    // (A) reference floor up to each barrier crest, tying the low-vs-high hump
+    // comparison to the Eₐ in the Arrhenius formula above. Gold marks the low
+    // B barrier, emerald the high C barrier.
+    const eaFloorY = sy(potential(0));
+    const eaMark = (xDom: number, color: RGB, side: -1 | 1) => {
+      const x = sx(xDom);
+      const yTop = sy(potential(xDom));
+      sctx.save();
+      sctx.globalCompositeOperation = 'source-over';
+      sctx.globalAlpha = 0.6;
+      sctx.strokeStyle = rgb(color, 1);
+      sctx.lineWidth = 1;
+      sctx.setLineDash([3, 3]);
+      sctx.beginPath();
+      sctx.moveTo(x, eaFloorY);
+      sctx.lineTo(x, yTop);
+      sctx.stroke();
+      sctx.restore();
+      label(sctx, 'Eₐ', x + side * 6, (yTop + eaFloorY) / 2 + 4, color, {
+        size: 11,
+        weight: 500,
+        align: side < 0 ? 'right' : 'left',
+        alpha: 0.6,
+      });
+    };
+    eaMark(-BX, colors.gold, -1);
+    eaMark(BX, colors.green, 1);
+
     // Region labels, tinted toward the product each side favors.
     label(sctx, 'B', sx(-WX), sy(-WELL_B) + 26, colors.gold, {
       size: 13,
@@ -230,26 +307,9 @@ export function createKineticsScene(
       alpha: 0.9,
     });
 
-    // Beads: glowing points that sit on the curve, piling up wherever the
-    // ensemble currently favors. Deterministic per-index jitter so a pile
-    // reads as a pile, not a jittery blob.
-    const { xs } = core;
-    const dot = 10.5;
-    sctx.save();
-    sctx.globalCompositeOperation = colors.blend;
-    for (let i = 0; i < xs.length; i++) {
-      const x = xs[i];
-      const inB = x < -0.4;
-      const inC = x > 0.4;
-      const sprite = inB ? goldSprite : inC ? greenSprite : neutralSprite;
-      sctx.globalAlpha = inB || inC ? colors.glowAlpha : colors.glowAlpha * 0.55;
-      const jx = (((i * 53) % 15) - 7) * 0.35;
-      const jy = ((i * 29) % 13) * 0.9;
-      const bx = sx(x) + jx;
-      const by = sy(potential(x)) - 4 - jy;
-      sctx.drawImage(sprite, bx - dot / 2, by - dot / 2, dot, dot);
-    }
-    sctx.restore();
+    // Composite the bead buffer (device pixels) over the fresh landscape.
+    sctx.setTransform(1, 0, 0, 1, 0, 0);
+    sctx.drawImage(trail, 0, 0);
   };
 
   const drawChart = () => {
@@ -325,6 +385,7 @@ export function createKineticsScene(
       core.reset();
       historyB = [];
       historyC = [];
+      clearTrail();
     },
     dispose() {
       cancelAnimationFrame(rafId);

--- a/src/lib/lab/millikan.ts
+++ b/src/lib/lab/millikan.ts
@@ -17,11 +17,11 @@ const TIME_SCALE = 18; // visual speed-up of the drift
 const BALANCE_V = 3e-6; // |drift| below this counts as "hovering" (m/s)
 
 interface Droplet {
-  /** radius, m (0.8–1.4 µm) */
+  /** radius, m (0.7–1.1 µm) */
   r: number;
   /** mass, kg */
   m: number;
-  /** charge, C — always n·e with hidden n */
+  /** charge magnitude, C — |q| = n·e of a negatively charged drop, n hidden */
   q: number;
   n: number;
   /** height above the bottom plate, m ∈ [0, PLATE_GAP] */
@@ -85,6 +85,7 @@ export function createMillikanSim(
   let voltage = 0;
   let records: number[] = [];
   let colors = themeColors();
+  let resetAt = 0; // timestamp of the last mid-chamber recenter, for the fade-in
 
   const driftVelocity = (): number =>
     (droplet.m * G - (droplet.q * voltage) / PLATE_GAP) / (6 * Math.PI * ETA_AIR * droplet.r);
@@ -106,7 +107,7 @@ export function createMillikanSim(
   window.addEventListener('resize', resize);
   resize();
 
-  const drawStage = () => {
+  const drawStage = (now: number) => {
     const dpr = Math.min(window.devicePixelRatio, 2);
     const w = stage.width / dpr;
     const h = stage.height / dpr;
@@ -119,8 +120,8 @@ export function createMillikanSim(
     const fieldAlpha = Math.min(0.65, voltage / 2500);
 
     // Capacitor plates: a polished instrument bar with a bright inner edge
-    // that energizes with the applied field. Top +, bottom − (field pushes
-    // positive charge up).
+    // that energizes with the applied field. Top +, bottom −: the field points
+    // down, so the negatively charged droplet feels an upward force qE.
     const drawPlate = (barY: number, edgeY: number) => {
       sctx.fillStyle = rgb(colors.inkMuted, colors.dark ? 0.8 : 0.85);
       sctx.fillRect(plateX, barY, plateW, 4);
@@ -170,15 +171,19 @@ export function createMillikanSim(
     const y = top + (1 - droplet.y / PLATE_GAP) * (bottom - top);
     const x = w / 2;
     const dropColor = balanced ? colors.green : colors.gold;
+    // After a recenter the bead fades back in over ~250 ms so the jump reads
+    // as a fresh view of the same drop rather than a rendering glitch.
+    const fade = Math.min(1, (now - resetAt) / 250);
 
-    glowDot(sctx, x, y, 6, dropColor, colors.glowAlpha + (colors.dark ? 0.1 : 0.3));
+    glowDot(sctx, x, y, 6, dropColor, (colors.glowAlpha + (colors.dark ? 0.1 : 0.3)) * fade);
     // A small bright highlight sells the "glass bead" read.
-    sctx.fillStyle = rgb(mix(dropColor, WHITE, colors.dark ? 0.55 : 0.25), colors.dark ? 0.85 : 0.55);
+    sctx.fillStyle = rgb(mix(dropColor, WHITE, colors.dark ? 0.55 : 0.25), (colors.dark ? 0.85 : 0.55) * fade);
     sctx.beginPath();
     sctx.arc(x - 1.7, y - 1.9, 1.5, 0, 2 * Math.PI);
     sctx.fill();
 
-    if (!balanced) {
+    // Suppress the drift arrow mid-fade so the reset doesn't flash a cue.
+    if (!balanced && fade >= 1) {
       const dir = v > 0 ? 1 : -1; // falling = down the screen
       const len = Math.min(26, 8 + Math.abs(v) * 4e6);
       glowStroke(
@@ -260,9 +265,10 @@ export function createMillikanSim(
     // Drifted out of view: bring it back mid-chamber (same hidden charge).
     if (droplet.y < 0.03 * PLATE_GAP || droplet.y > 0.97 * PLATE_GAP) {
       droplet.y = PLATE_GAP / 2;
+      resetAt = now;
     }
     onUpdate?.(v, Math.abs(v) < BALANCE_V);
-    drawStage();
+    drawStage(now);
     drawChart();
   };
   const onVisibility = () => {

--- a/src/lib/lab/molecules.ts
+++ b/src/lib/lab/molecules.ts
@@ -68,8 +68,12 @@ export interface MoleculesSim {
   /** Piston compression 0 (open) → 1 (max), only acts in adiabatic mode. */
   setCompression(c: number): void;
   reset(): void;
-  /** Mean kinetic energy per particle (the measured temperature). */
+  /** Mean kinetic energy per particle (the measured temperature). Drives the
+   *  physics; fluctuates ~±1/√N frame to frame. */
   readonly measuredT: number;
+  /** Render-smoothed low-pass of measuredT — drive the on-screen readouts and
+   *  phase label off this so the digits don't flicker on the raw estimate. */
+  readonly displayT: number;
   /** Available volume fraction (1 = open box), for the adiabatic readout. */
   readonly volumeFraction: number;
   dispose(): void;
@@ -272,7 +276,10 @@ export function createMoleculesSim(stage: HTMLCanvasElement): MoleculesSim {
     const rH = rO * 0.62;
     const bond = SIGMA * 0.42 * scale;
     // Internal vibration amplitude grows with √T (stretch + bend wobble).
-    const vibAmp = 0.28 * Math.sqrt(Math.min(2, targetT));
+    // Driven by the actual (render-smoothed) temperature, not the slider
+    // target, so under adiabatic compression the wobble grows with the heating
+    // gas instead of freezing at whatever the slider last read.
+    const vibAmp = 0.28 * Math.sqrt(Math.min(2, displayT));
     const halfHOH = (104.5 / 2 / 180) * Math.PI;
     const oDot = rO * 3.4;
     const hDot = rH * 4.0;
@@ -359,6 +366,9 @@ export function createMoleculesSim(stage: HTMLCanvasElement): MoleculesSim {
     reset,
     get measuredT() {
       return measuredT;
+    },
+    get displayT() {
+      return displayT;
     },
     get volumeFraction() {
       return Math.max(0.05, 1 - ceiling);

--- a/src/lib/lab/polarizer.ts
+++ b/src/lib/lab/polarizer.ts
@@ -36,6 +36,13 @@ export function stageIntensities(s: PolarizerState): number[] {
 const clamp01 = (v: number) => (v < 0 ? 0 : v > 1 ? 1 : v);
 const WHITE: RGB = [255, 255, 255];
 
+/** Horizontal foreshortening of the filter plane. The bench is viewed at a
+ *  slight tilt, so each disk (perpendicular to the beam) reads as an ellipse
+ *  and the in-plane horizontal axis is compressed to this fraction. Every
+ *  in-plane quantity — ring, hatch, E-field arrows — is projected through the
+ *  same factor so all angles live in one consistent plane. */
+const PLANE_X = 0.42;
+
 /** Generalized glowStroke for arbitrary (possibly multi-subpath) paths — used
  *  for the E-field arrows and filter rings, which glowStroke's polyline API
  *  can't express. Mirrors glowStroke's own dark/light convention exactly. */
@@ -99,57 +106,92 @@ export function createPolarizerScene(canvas: HTMLCanvasElement): PolarizerScene 
   window.addEventListener('resize', resize);
   resize();
 
-  /** Filter disk: a fine hatch marks the transmission axis; the ring's glow
-   *  brightens with how much light this filter is actually passing. */
+  /** Filter disk, seen as a foreshortened ellipse in the tilted bench plane.
+   *  The faint hatch runs along the iodine chains (the "wires" that absorb the
+   *  parallel field); a brighter gold line marks the perpendicular
+   *  transmission axis that light actually passes. The ring's glow brightens
+   *  with how much light this filter is passing. */
   const drawFilter = (x: number, y: number, r: number, deg: number, labelText: string, throughput: number) => {
     const glowT = clamp01(throughput / 0.5);
-    ctx.save();
-    ctx.translate(x, y);
+    const rad = (deg * Math.PI) / 180;
+    const cs = Math.cos(rad);
+    const sn = Math.sin(rad);
+    // Project a disk-local point (a = along transmission axis, b = along the
+    // chains) into screen space, foreshortening the in-plane horizontal by
+    // PLANE_X so the disk reads as a tilted plane.
+    const proj = (a: number, b: number): [number, number] => [
+      x + (a * sn + b * cs) * PLANE_X,
+      y - (a * cs - b * sn),
+    ];
 
-    ctx.save();
-    ctx.rotate((deg * Math.PI) / 180);
+    // Hatch = iodine chains, perpendicular to the transmission axis.
     ctx.strokeStyle = rgb(t.inkMuted, t.dark ? 0.3 : 0.38);
     ctx.lineWidth = 1;
     ctx.beginPath();
-    for (let o = -r + 7; o < r; o += 7) {
-      const half = Math.sqrt(Math.max(0, r * r - o * o)) - 2;
+    for (let a = -r + 7; a < r; a += 7) {
+      const half = Math.sqrt(Math.max(0, r * r - a * a)) - 2;
       if (half <= 0) continue;
-      ctx.moveTo(o, -half);
-      ctx.lineTo(o, half);
+      const [x1, y1] = proj(a, -half);
+      const [x2, y2] = proj(a, half);
+      ctx.moveTo(x1, y1);
+      ctx.lineTo(x2, y2);
     }
     ctx.stroke();
-    ctx.restore();
 
+    // Transmission axis: a subtle double-headed gold tick across the disk.
+    const [ax1, ay1] = proj(-r + 3, 0);
+    const [ax2, ay2] = proj(r - 3, 0);
+    ctx.strokeStyle = rgb(sampleRamp(goldR, 0.55 + 0.4 * glowT), t.dark ? 0.55 : 0.62);
+    ctx.lineWidth = 1.4;
+    ctx.beginPath();
+    ctx.moveTo(ax1, ay1);
+    ctx.lineTo(ax2, ay2);
+    ctx.stroke();
+
+    // Ring: an ellipse, foreshortened horizontally (a circle in the tilted
+    // plane projects to the same ellipse regardless of the axis angle).
     const ringColor = mix(t.inkMuted, sampleRamp(goldR, glowT), 0.3 + 0.55 * glowT);
     const ringPath = () => {
       ctx.beginPath();
-      ctx.arc(0, 0, r, 0, 2 * Math.PI);
+      ctx.ellipse(x, y, r * PLANE_X, r, 0, 0, 2 * Math.PI);
     };
     strokeGlowPath(ctx, ringPath, ringColor, 1.4, t.glowAlpha * (0.2 + 0.6 * glowT), t.dark);
-    ctx.restore();
 
     label(ctx, labelText, x, y + r + 20, t.inkMuted, { size: 12, align: 'center' });
   };
 
-  /** Double-headed E-field arrow at screen angle θ from vertical, glowing. */
+  /** Double-headed E-field arrow at angle θ from vertical, living in the same
+   *  tilted plane as the filters: the vertical reach is full, the in-plane
+   *  horizontal reach is foreshortened by PLANE_X. A near-horizontal field
+   *  (θ→90°) therefore reads as poking into the bench rather than running
+   *  along the beam. */
   const drawEArrow = (x: number, y: number, deg: number, len: number, pulse: number) => {
     if (len < 2) return;
     const l = len * (0.75 + 0.25 * pulse);
-    ctx.save();
-    ctx.translate(x, y);
-    ctx.rotate((deg * Math.PI) / 180);
+    const rad = (deg * Math.PI) / 180;
+    // Projected axis offset from centre to tip (screen up = negative y).
+    const ox = Math.sin(rad) * PLANE_X;
+    const oy = -Math.cos(rad);
+    const mag = Math.hypot(ox, oy) || 1;
+    const hx = ox / mag; // unit heading, for the arrowheads
+    const hy = oy / mag;
+    const px = -hy; // unit perpendicular, for the barbs
+    const py = hx;
     const path = () => {
       ctx.beginPath();
-      ctx.moveTo(0, -l);
-      ctx.lineTo(0, l);
+      ctx.moveTo(x - ox * l, y - oy * l);
+      ctx.lineTo(x + ox * l, y + oy * l);
       for (const dir of [-1, 1]) {
-        ctx.moveTo(-3.5, dir * (l - 5));
-        ctx.lineTo(0, dir * l);
-        ctx.lineTo(3.5, dir * (l - 5));
+        const ex = x + dir * ox * l;
+        const ey = y + dir * oy * l;
+        const bx = ex - dir * hx * 5;
+        const by = ey - dir * hy * 5;
+        ctx.moveTo(bx + px * 3.5, by + py * 3.5);
+        ctx.lineTo(ex, ey);
+        ctx.lineTo(bx - px * 3.5, by - py * 3.5);
       }
     };
     strokeGlowPath(ctx, path, t.green, 1.8, t.glowAlpha * (0.45 + 0.35 * pulse), t.dark);
-    ctx.restore();
   };
 
   /** Unpolarized light: arrows in every direction. */
@@ -254,6 +296,21 @@ export function createPolarizerScene(canvas: HTMLCanvasElement): PolarizerScene 
     ctx.strokeStyle = rgb(t.inkMuted, t.dark ? 0.55 : 0.7);
     ctx.lineWidth = 1.2;
     ctx.strokeRect(meterX, meterTop, 18, meterH);
+
+    // Ideal-filter ceiling: unpolarized light through any polarizer chain caps
+    // at I₀/2, so the fill can never pass this half-way line. Mark it so a
+    // maxed-out meter doesn't read as stuck or broken.
+    const ceilY = meterBottom - meterH * 0.5;
+    ctx.save();
+    ctx.setLineDash([3, 3]);
+    ctx.strokeStyle = rgb(t.inkMuted, t.dark ? 0.5 : 0.6);
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(meterX - 3, ceilY);
+    ctx.lineTo(meterX + 18, ceilY);
+    ctx.stroke();
+    ctx.restore();
+    label(ctx, '50%', meterX - 7, ceilY + 3.5, t.inkMuted, { size: 9, align: 'right' });
 
     if (out > 0.001) {
       const grad = ctx.createLinearGradient(0, filledTop, 0, meterBottom);

--- a/src/lib/lab/polymer.ts
+++ b/src/lib/lab/polymer.ts
@@ -55,9 +55,18 @@ export interface PolymerScene {
   dispose(): void;
 }
 
+/** Localized on-canvas labels (falls back to English/neutral defaults). */
+export interface PolymerLabels {
+  /** Name of the incoming monomer, drawn beneath it as it approaches. */
+  monomer: string;
+  /** Formula for the pendant side group, drawn by the first methyl. */
+  methyl: string;
+}
+
 export function createPolymerScene(
   canvas: HTMLCanvasElement,
   onUpdate?: (units: number, tacticity: Tacticity) => void,
+  labels: PolymerLabels = { monomer: 'propylene', methyl: 'CH₃' },
 ): PolymerScene {
   const ctx = canvas.getContext('2d')!;
   let tacticity: Tacticity = 'isotactic';
@@ -111,9 +120,16 @@ export function createPolymerScene(
     // Backbone zig-zag geometry. Each repeat unit = 2 backbone carbons
     // (–CH₂– then the –CH(CH₃)– that carries the methyl).
     const midY = h * 0.52;
-    const amp = Math.min(24, h * 0.09);
     const totalCarbons = MAX_UNITS * 2 + 1;
     const dx = (w * 0.82) / totalCarbons;
+    // Cap the zig-zag amplitude by the horizontal pitch so the bond angle
+    // stays plausible on narrow phones — otherwise the chain degenerates into
+    // near-vertical needle spikes when dx shrinks. dx*1.15 keeps a roughly
+    // tetrahedral-looking ~109° zig-zag.
+    const amp = Math.min(24, h * 0.09, dx * 1.15);
+    // Shrink glow radii along with the pitch so halos don't smear across
+    // adjacent carbons at small dx.
+    const rScale = Math.min(1, Math.max(0.62, dx / 16));
     const x0 = w * 0.09;
     const cx = (i: number) => x0 + i * dx;
     const cyOf = (i: number) => midY + (i % 2 === 0 ? -amp : amp);
@@ -156,7 +172,7 @@ export function createPolymerScene(
       ctx.lineTo(bx, my);
       ctx.stroke();
       ctx.restore();
-      glowDot(ctx, bx, my, 3.6, sampleRamp(colors.gold, t), colors.glowAlpha);
+      glowDot(ctx, bx, my, 3.6 * rScale, sampleRamp(colors.gold, t), colors.glowAlpha);
     }
 
     // Backbone carbons — soft emerald glow; the open (growing) end pulses
@@ -164,61 +180,187 @@ export function createPolymerScene(
     for (let i = 0; i < drawnCarbons; i++) {
       const t = depthT(i / (totalCarbons - 1));
       const isTip = i === drawnCarbons - 1 && units < MAX_UNITS;
-      const r = i % 2 === 1 ? 3.6 : 3;
+      const r = (i % 2 === 1 ? 3.6 : 3) * rScale;
       const boost = isTip ? 1 + 0.5 * grow : 1;
       glowDot(ctx, cx(i), cyOf(i), r, sampleRamp(colors.emerald, t), colors.glowAlpha * boost);
     }
 
-    // Incoming monomer CH₂=CHCH₃ approaching the growing (right) end: its
-    // C=C double bond glows, cooling from reactive gold toward backbone
-    // emerald as it opens and clicks into place.
+    // Incoming propylene monomer CH₂=CH(CH₃) docking onto the growing end.
+    // For most of the cycle it glides in from the right with an intact C=C
+    // double bond (gold, reactive). In the final stretch it "docks": the two
+    // sp² carbons slide onto the next two zig-zag vertices, the double bond
+    // opens (its second π line fades away) into a single backbone σ bond, and
+    // the colour cools from gold toward emerald — so the click into place is
+    // drawn, and at the wrap the monomer *is* the two new backbone carbons.
     if (units < MAX_UNITS) {
-      const endI = drawnCarbons - 1;
-      const ex = cx(endI);
-      const ey = cyOf(endI);
-      const approach = 1 - grow;
-      const mx = ex + dx * (1.8 + approach * 3);
-      const my = ey - amp * 0.4;
-      const alphaFactor = 0.55 + 0.45 * grow;
+      const endI = drawnCarbons - 1; // current open chain end
+      const ox = cx(endI);
+      const oy = cyOf(endI);
+
+      // Landing vertices: the substituted (methyl-bearing) carbon lands on the
+      // next odd index; the CH₂ carbon becomes the new open end.
+      const t1x = cx(endI + 1);
+      const t1y = cyOf(endI + 1);
+      const t2x = cx(endI + 2);
+      const t2y = cyOf(endI + 2);
+
+      // Glide during the first ~65%, then dock (smoothstepped) in the tail.
+      const DOCK_START = 0.65;
+      const glide = Math.min(grow / DOCK_START, 1);
+      const dockRaw = Math.max(0, (grow - DOCK_START) / (1 - DOCK_START));
+      const dock = dockRaw * dockRaw * (3 - 2 * dockRaw);
+
+      // Monomer centre glides from far right to a staging point above the
+      // landing zone; its two C=C carbons sit above/below it (vertical bond).
+      const halfBond = 7;
+      const ccx = (t2x + dx * 4.2) + ((t2x + dx * 1.3) - (t2x + dx * 4.2)) * glide;
+      const ccy = (midY - amp * 1.3) + ((midY - amp * 0.6) - (midY - amp * 1.3)) * glide;
+      const a1x = ccx;
+      const a1y = ccy - halfBond;
+      const a2x = ccx;
+      const a2y = ccy + halfBond;
+
+      // Dock: interpolate each carbon from its approach point onto its vertex.
+      const c1x = a1x + (t1x - a1x) * dock;
+      const c1y = a1y + (t1y - a1y) * dock;
+      const c2x = a2x + (t2x - a2x) * dock;
+      const c2y = a2y + (t2y - a2y) * dock;
+
       const bondColor = mix(sampleRamp(colors.gold, 0.7), sampleRamp(colors.emerald, 0.8), grow);
       const bondGlow = 0.5 + 0.6 * grow;
+      const alphaFactor = 0.55 + 0.45 * grow;
 
-      // C=C double bond (two glowing parallel lines).
-      for (const off of [-2, 2]) {
+      // Forming σ bond from the chain's open end to the docking carbon: it
+      // brightens as the monomer clicks in and coincides with the finished
+      // backbone segment at dock = 1 (so nothing pops when the unit completes).
+      if (dock > 0) {
         glowStroke(
           ctx,
           [
-            { x: mx + off, y: my - 7 },
-            { x: mx + off, y: my + 7 },
+            { x: ox, y: oy },
+            { x: c1x, y: c1y },
           ],
-          bondColor,
-          1.6,
-          bondGlow,
+          sampleRamp(colors.emerald, 0.72),
+          2.2,
+          dock,
           colors.dark,
         );
       }
-      for (const dyc of [-7, 7]) {
-        glowDot(ctx, mx, my + dyc, 4, bondColor, colors.glowAlpha * alphaFactor * (0.85 + 0.35 * grow));
+
+      // C=C: the surviving σ line c1→c2, plus a parallel π line that fades out
+      // as the double bond opens.
+      glowStroke(
+        ctx,
+        [
+          { x: c1x, y: c1y },
+          { x: c2x, y: c2y },
+        ],
+        bondColor,
+        1.8,
+        bondGlow,
+        colors.dark,
+      );
+      const piAlpha = 1 - dock;
+      if (piAlpha > 0.02) {
+        const bvx = c2x - c1x;
+        const bvy = c2y - c1y;
+        const blen = Math.hypot(bvx, bvy) || 1;
+        const perpX = (-bvy / blen) * 2.4;
+        const perpY = (bvx / blen) * 2.4;
+        ctx.save();
+        ctx.globalAlpha = piAlpha;
+        glowStroke(
+          ctx,
+          [
+            { x: c1x + perpX, y: c1y + perpY },
+            { x: c2x + perpX, y: c2y + perpY },
+          ],
+          bondColor,
+          1.4,
+          bondGlow,
+          colors.dark,
+        );
+        ctx.restore();
       }
-      // Its methyl stub.
+
+      // The two carbons — alpha and radius resolve to the backbone dots at
+      // dock = 1 so the completed unit inherits them seamlessly.
+      const dotAlpha = colors.glowAlpha * (alphaFactor + (1 - alphaFactor) * dock);
+      glowDot(ctx, c1x, c1y, 3.6 * rScale * (0.9 + 0.1 * dock), bondColor, dotAlpha);
+      glowDot(ctx, c2x, c2y, 3 * rScale * (0.9 + 0.1 * dock), bondColor, dotAlpha);
+
+      // Methyl stub — swings onto its final tacticity side as it docks so it
+      // doesn't jump when the unit locks in.
+      const mSide = methylSide(tacticity, units, seed);
+      const mAppX = a1x + 9;
+      const mAppY = a1y - 8;
+      const mEndX = mAppX + (t1x - mAppX) * dock;
+      const mEndY = mAppY + (t1y + mSide * amp * 1.4 - mAppY) * dock;
       ctx.save();
       ctx.globalAlpha = alphaFactor;
       ctx.strokeStyle = rgb(colors.inkMuted, colors.dark ? 0.6 : 0.75);
       ctx.lineWidth = 1.4;
       ctx.beginPath();
-      ctx.moveTo(mx, my + 7);
-      ctx.lineTo(mx + 9, my + 14);
+      ctx.moveTo(c1x, c1y);
+      ctx.lineTo(mEndX, mEndY);
       ctx.stroke();
       ctx.restore();
-      glowDot(ctx, mx + 9, my + 14, 3.2, sampleRamp(colors.gold, 0.6), colors.glowAlpha * alphaFactor);
+      const mT = depthT((endI + 1) / (totalCarbons - 1));
+      glowDot(
+        ctx,
+        mEndX,
+        mEndY,
+        (3.2 + 0.4 * dock) * rScale,
+        mix(sampleRamp(colors.gold, 0.6), sampleRamp(colors.gold, mT), dock),
+        dotAlpha,
+      );
+
+      // Name the monomer while it is still a recognizable separate molecule.
+      const monoAlpha = 0.75 * glide * (1 - dock);
+      if (monoAlpha > 0.03) {
+        label(ctx, labels.monomer, ccx, Math.max(c1y, c2y) + 16, colors.inkMuted, {
+          size: 11,
+          align: 'center',
+          alpha: monoAlpha,
+        });
+      }
     }
 
-    // "n" bracket label at the chain end.
-    label(ctx, `( … )n = ${units}`, x0, h * 0.9, colors.inkMuted, {
-      size: 13,
-      weight: 500,
-      alpha: 0.85,
-    });
+    // –[ … ]ₙ– bracket framing the completed repeat units, with a subscript n
+    // — teaches the notation from the formula block and grows as units add.
+    if (units >= 1) {
+      const yTop = midY - amp * 1.95;
+      const yBot = midY + amp * 1.95;
+      const xL = x0 + dx * 0.5;
+      const xR = x0 + (units * 2 + 0.5) * dx;
+      const tick = Math.max(5, dx * 0.32);
+      ctx.save();
+      ctx.strokeStyle = rgb(colors.inkMuted, colors.dark ? 0.45 : 0.55);
+      ctx.lineWidth = 1.4;
+      ctx.beginPath();
+      ctx.moveTo(xL + tick, yTop);
+      ctx.lineTo(xL, yTop);
+      ctx.lineTo(xL, yBot);
+      ctx.lineTo(xL + tick, yBot);
+      ctx.moveTo(xR - tick, yTop);
+      ctx.lineTo(xR, yTop);
+      ctx.lineTo(xR, yBot);
+      ctx.lineTo(xR - tick, yBot);
+      ctx.stroke();
+      ctx.restore();
+      label(ctx, 'n', xR + 5, yBot - 1, colors.inkMuted, { size: 13, weight: 600, alpha: 0.85 });
+
+      // Name the pendant group on the first methyl so the gold dots aren't
+      // anonymous.
+      const s0 = methylSide(tacticity, 0, seed);
+      const m0x = cx(1);
+      const m0y = cyOf(1) + s0 * amp * 1.4;
+      label(ctx, labels.methyl, m0x + 7 * rScale, m0y + (s0 > 0 ? -6 : 13), sampleRamp(colors.gold, 0.85), {
+        size: 11,
+        weight: 500,
+        alpha: 0.85,
+      });
+    }
   };
   rafId = requestAnimationFrame(draw);
 

--- a/src/lib/lab/tunnel.ts
+++ b/src/lib/lab/tunnel.ts
@@ -268,7 +268,10 @@ export function createTunnelScene(
     // tail that has tunneled past the barrier glows brighter — the part of
     // the story worth lingering on.
     const { re, im } = core;
-    const psiScale = h * 5.2;
+    // Scale chosen so the reflection standing wave (incident + reflected
+    // interference peaks at ~4× the incident density) still clears the top
+    // edge in the high-V₀ / wide-L runs the hint encourages.
+    const psiScale = h * 4.4;
     const pts: { x: number; y: number }[] = [];
     for (let j = 0; j < N; j++) {
       const p = re[j] * re[j] + im[j] * im[j];

--- a/src/lib/lab/well.ts
+++ b/src/lib/lab/well.ts
@@ -84,10 +84,21 @@ export function createWellScene(canvas: HTMLCanvasElement): WellScene {
     const boxW = (w - 2 * padX) * L;
     const bx0 = w / 2 - boxW / 2;
     const bx1 = w / 2 + boxW / 2;
-    const eY = (E: number) => bottom - (E / E_AXIS_MAX) * (bottom - top);
+    // Square-root-compressed energy axis. A linear axis crushes the low levels:
+    // at L=1 the E₁=1 rung sits a few px above the floor, hiding the zero-point
+    // gap and letting the ground-state wave dip below the box. Mapping through
+    // √E lifts E₁ well clear of the floor and spaces the rungs wide enough that
+    // the standing wave no longer breaks through — the ladder still climbs as
+    // the box narrows, so all three lessons survive (trade-off: the n² rung
+    // spacing reads as ∝ n rather than widening).
+    const eY = (E: number) => bottom - Math.sqrt(E / E_AXIS_MAX) * (bottom - top);
 
-    // Standing-wave oscillation: Re(ψ e^{-iEt}) = ψ cos(Et). Faster for higher E.
-    const phase = Math.cos(t * energy(n, L) * 1.1);
+    // Standing-wave oscillation: Re(ψ e^{-iEt}) = ψ cos(Et). The true rate ∝ E
+    // aliases into flicker at high n (≈17 Hz at n=6/L=0.6 vs the 60fps rAF), so
+    // the animation clock runs through √E instead — still monotonic in E, so
+    // "higher level breathes faster" reads, but the top speed drops to a
+    // legible ≈1.75 Hz.
+    const phase = Math.cos(t * 1.1 * Math.sqrt(energy(n, L)));
 
     // Well walls (infinite potential) — a single quiet, faintly luminous line.
     glowStroke(

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -337,26 +337,8 @@ a {
   accent-color: var(--accent);
 }
 
-/* Governing equation, set like a display formula in a paper */
-.lab-formula {
-  position: relative;
-  margin-top: 1.4rem;
-  padding: 0.8rem 1.2rem;
-  border-left: 2px solid transparent;
-  border-image: linear-gradient(180deg, var(--accent), color-mix(in srgb, #d9b36c 70%, var(--accent))) 1;
-  background: linear-gradient(90deg, color-mix(in srgb, var(--accent) 7%, transparent), transparent 70%);
-  border-radius: 0 8px 8px 0;
-  font-family: var(--font-display);
-  font-size: 1.05rem;
-  letter-spacing: 0.02em;
-  color: var(--ink-secondary);
-  overflow-x: auto;
-  white-space: nowrap;
-}
-
-.lab-formula i {
-  font-style: italic;
-}
+/* Governing equations are now typeset with KaTeX via the <Formula> component
+   (see src/components/Formula.astro, class .lab-eq). */
 
 /* Living preview on the lab index tiles (framed by .lab-thumb-frame) */
 .lab-thumb {


### PR DESCRIPTION
Audited every `/lab` piece for **explanation clarity / formula typography / 3D & visual quality**, then applied fixes. Build passes, TypeScript clean, no console errors; a representative sample verified in-browser (ja + en).

## 数式 — formula beauty
New build-time **`<Formula>` component** (`src/components/Formula.astro`) renders every governing equation with **KaTeX** — real stacked fractions/radicals/subscripts, self-hosted fonts (19 woff2 emitted by Vite), **zero client JS**, `throwOnError` so bad LaTeX fails the build. All 14 pages migrated off the hand-set ASCII/Unicode fake-fraction blocks; the dead `.lab-formula` CSS is removed.

## 説明 — clarity (several were real bugs)
- **Fusion**: restored the **mojibake English copy** (`ÎmÂ·cÂ²` → clean text)
- **Chirality**: localized the formula that was **hardcoded Japanese on /en**
- **Hydrogen**: corrected the isotope note (the electron cloud does **not** change)
- **Millikan**: state the droplet's negative charge (a code comment said the opposite)
- **Polymer (JA)**: Ziegler–Natta actually won the 1963 Nobel; added density unit
- **Kinetics (EN)**: fixed the inverted diamond/graphite stability claim
- **Molecules (JA)**: fixed a doubled-を grammar break
- Plus intro-first rewrites, run-on splits (fission/fusion), and stale-hint fixes (entropy)

## 3D / visuals
- **Hydrogen**: depth-sorted rendering (light-mode lobe ordering) + theme-matched legend
- **Polarizer**: foreshortened projection with consistent in-plane E-field arrows
- **Polymer**: monomer now **docks** onto the backbone (no jump cut)
- **Chirality**: on-canvas Receptor/Drug labels
- Also: well energy-axis compression + de-strobe, kinetics dark-mode blending + barrier labels, entropy/ising/fission/fusion chart labels, molecules vibration coupling, tunnel wave-clipping, millikan reset softening

## Notes
- Adds `katex` + `@types/katex`.
- 32 files: +1 component, 14 page components, 14 lib/sim files, `global.css`, `package.json`/`bun.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)